### PR TITLE
Add automatic root node creation

### DIFF
--- a/client/src/components/NodeList.js
+++ b/client/src/components/NodeList.js
@@ -72,8 +72,12 @@ export default function NodeList({ modelId, open, onClose }) {
 
   const handleDelete = async (id) => {
     if (window.confirm('¿Eliminar elemento?')) {
-      await axios.delete(`/api/nodes/${id}`);
-      load();
+      try {
+        await axios.delete(`/api/nodes/${id}`);
+        load();
+      } catch (e) {
+        alert(e.response?.data?.error || 'Error');
+      }
     }
   };
 
@@ -101,7 +105,14 @@ export default function NodeList({ modelId, open, onClose }) {
               {n.name}
               <Button size="small" onClick={() => openCreate(n.id)}>Añadir</Button>
               <Button size="small" onClick={() => openEdit(n)}>Editar</Button>
-              <Button size="small" color="error" onClick={() => handleDelete(n.id)}>Eliminar</Button>
+              <Button
+                size="small"
+                color="error"
+                onClick={() => handleDelete(n.id)}
+                disabled={n.name === 'Raiz' && n.parentId === null}
+              >
+                Eliminar
+              </Button>
             </div>
           }
         >

--- a/server/index.js
+++ b/server/index.js
@@ -104,6 +104,8 @@ app.get('/api/models', async (req, res) => {
 
 app.post('/api/models', async (req, res) => {
   const model = await Model.create(req.body);
+  // Create root node automatically
+  await Node.create({ name: 'Raiz', modelId: model.id, parentId: null });
   res.json(model);
 });
 
@@ -195,6 +197,10 @@ app.put('/api/nodes/:id', async (req, res) => {
 });
 
 app.delete('/api/nodes/:id', async (req, res) => {
+  const node = await Node.findByPk(req.params.id);
+  if (node && node.name === 'Raiz' && node.parentId === null) {
+    return res.status(400).json({ error: 'No se puede eliminar el nodo raiz' });
+  }
   await Node.destroy({ where: { id: req.params.id } });
   res.json({});
 });


### PR DESCRIPTION
## Summary
- automatically create root node `Raiz` when a new model is created
- forbid deletion of the root node from API
- show error if root deletion is attempted and disable delete button for it in the UI

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b23c8d308833187816793de798765