### PR TITLE
Add document categories and node attachments

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Header from './components/Header';
 import ModelList from './components/ModelList';
 import ParameterList from './components/ParameterList';
+import DocumentCategoryList from './components/DocumentCategoryList';
 import axios from 'axios';
 import Container from '@mui/material/Container';
 
@@ -9,6 +10,7 @@ function App() {
   const [showModels, setShowModels] = React.useState(false);
   const [showPublicModels, setShowPublicModels] = React.useState(false);
   const [showParams, setShowParams] = React.useState(false);
+  const [showCats, setShowCats] = React.useState(false);
   const [appName, setAppName] = React.useState('MCM');
 
   const loadName = async () => {
@@ -23,17 +25,19 @@ function App() {
 
   React.useEffect(() => { loadName(); }, []);
 
-  const closeAll = () => { setShowModels(false); setShowParams(false); setShowPublicModels(false); };
+  const closeAll = () => { setShowModels(false); setShowParams(false); setShowPublicModels(false); setShowCats(false); };
 
   return (
     <div>
       <Header appName={appName}
               onModels={() => { closeAll(); setShowPublicModels(true); }}
               onAdmin={() => { closeAll(); setShowModels(true); }}
+              onCategories={() => { closeAll(); setShowCats(true); }}
               onParams={() => { closeAll(); setShowParams(true); }} />
       <Container sx={{ mt: 2 }}>
         {showPublicModels && <ModelList readOnly initialView="cards" />}
         {showModels && <ModelList />}
+        {showCats && <DocumentCategoryList open={showCats} onClose={() => setShowCats(false)} />}
         {showParams && <ParameterList />}
       </Container>
     </div>

--- a/client/src/components/DocumentCategoryList.js
+++ b/client/src/components/DocumentCategoryList.js
@@ -1,0 +1,183 @@
+import React from 'react';
+import axios from 'axios';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Card from '@mui/material/Card';
+import Typography from '@mui/material/Typography';
+import CardContent from '@mui/material/CardContent';
+import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import { jsPDF } from 'jspdf';
+
+function csvExport(data) {
+  const header = 'Nombre';
+  const rows = data.map(c => `${c.name}`);
+  const csvContent = [header, ...rows].join('\n');
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.setAttribute('href', url);
+  link.setAttribute('download', 'categorias.csv');
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+function pdfExport(data) {
+  const doc = new jsPDF();
+  doc.text('Categorías', 10, 10);
+  let y = 20;
+  data.forEach(c => {
+    doc.text(c.name, 10, y);
+    y += 10;
+  });
+  doc.save('categorias.pdf');
+}
+
+export default function DocumentCategoryList({ open, onClose }) {
+  const [cats, setCats] = React.useState([]);
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [editing, setEditing] = React.useState(null);
+  const [view, setView] = React.useState('table');
+  const [form, setForm] = React.useState({ name: '' });
+  const [showFilters, setShowFilters] = React.useState(false);
+  const [filter, setFilter] = React.useState('');
+  const [sort, setSort] = React.useState({ key: 'name', dir: 'asc' });
+
+  const load = async () => {
+    const res = await axios.get('/api/document-categories');
+    setCats(res.data);
+  };
+
+  React.useEffect(() => { if (open) load(); }, [open]);
+
+  const handleSave = async () => {
+    if (editing) {
+      await axios.put(`/api/document-categories/${editing.id}`, form);
+    } else {
+      await axios.post('/api/document-categories', form);
+    }
+    setDialogOpen(false);
+    setForm({ name: '' });
+    setEditing(null);
+    load();
+  };
+
+  const handleDelete = async (id) => {
+    if (window.confirm('¿Eliminar elemento?')) {
+      await axios.delete(`/api/document-categories/${id}`);
+      load();
+    }
+  };
+
+  const openEdit = (cat) => {
+    setEditing(cat);
+    setForm({ name: cat.name });
+    setDialogOpen(true);
+  };
+
+  const openCreate = () => {
+    setEditing(null);
+    setForm({ name: '' });
+    setDialogOpen(true);
+  };
+
+  const filtered = cats.filter(c =>
+    c.name.toLowerCase().includes(filter.toLowerCase())
+  );
+
+  const sorted = filtered.sort((a,b)=>{
+    const valA = a[sort.key];
+    const valB = b[sort.key];
+    if (valA < valB) return sort.dir === 'asc' ? -1 : 1;
+    if (valA > valB) return sort.dir === 'asc' ? 1 : -1;
+    return 0;
+  });
+
+  const toggleSort = key => {
+    setSort(prev => ({ key, dir: prev.key === key && prev.dir === 'asc' ? 'desc' : 'asc' }));
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>Categorías de documento</DialogTitle>
+      <DialogContent>
+        <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>Cambiar vista</Button>
+        <Button onClick={openCreate}>Nueva</Button>
+        <Button onClick={() => csvExport(cats)}>Exportar CSV</Button>
+        <Button onClick={() => pdfExport(cats)}>Exportar PDF</Button>
+        <IconButton onClick={() => setShowFilters(!showFilters)}>
+          <FilterListIcon />
+        </IconButton>
+        {showFilters && (
+          <div style={{ margin: '1rem 0' }}>
+            <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
+            <Button onClick={() => setFilter('')}>Reset</Button>
+          </div>
+        )}
+        {view === 'table' ? (
+          <TableContainer component={Paper} sx={{ mt: 2 }}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell onClick={() => toggleSort('name')} style={{ fontWeight: 'bold' }}>Nombre</TableCell>
+                  <TableCell style={{ fontWeight: 'bold' }}>Acciones</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {sorted.map((cat) => (
+                  <TableRow key={cat.id}>
+                    <TableCell>{cat.name}</TableCell>
+                    <TableCell>
+                      <Button onClick={() => openEdit(cat)}>Editar</Button>
+                      <Button color="error" onClick={() => handleDelete(cat.id)}>Eliminar</Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        ) : (
+          <Grid container spacing={2} sx={{ mt: 2 }}>
+            {sorted.map((cat) => (
+              <Grid item xs={12} md={4} key={cat.id}>
+                <Card>
+                  <CardContent>
+                    <Typography variant="h6">{cat.name}</Typography>
+                    <Button onClick={() => openEdit(cat)}>Editar</Button>
+                    <Button color="error" onClick={() => handleDelete(cat.id)}>Eliminar</Button>
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        )}
+        <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
+          <DialogTitle>{editing ? 'Editar' : 'Nueva'} categoría</DialogTitle>
+          <DialogContent>
+            <TextField required label="Nombre *" value={form.name} onChange={(e) => setForm({ name: e.target.value })} fullWidth />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setDialogOpen(false)}>Cancelar</Button>
+            <Button onClick={handleSave}>Guardar</Button>
+          </DialogActions>
+        </Dialog>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cerrar</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -7,7 +7,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import SettingsIcon from '@mui/icons-material/Settings';
 
-export default function Header({ appName, onAdmin, onParams, onModels }) {
+export default function Header({ appName, onAdmin, onParams, onModels, onCategories }) {
   const [anchorEl, setAnchorEl] = React.useState(null);
 
   const handleSettingsClick = (event) => {
@@ -30,6 +30,7 @@ export default function Header({ appName, onAdmin, onParams, onModels }) {
         </IconButton>
         <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
           <MenuItem onClick={() => { handleClose(); onAdmin(); }}>Gestión de modelos</MenuItem>
+          <MenuItem onClick={() => { handleClose(); onCategories(); }}>Categorías doc</MenuItem>
           <MenuItem onClick={() => { handleClose(); onParams(); }}>Parámetros</MenuItem>
         </Menu>
       </Toolbar>

--- a/client/src/components/NodeList.js
+++ b/client/src/components/NodeList.js
@@ -53,6 +53,9 @@ export default function NodeList({ modelId, open, onClose }) {
   const [filter, setFilter] = React.useState('');
   const [tags, setTags] = React.useState([]);
   const [selectedTags, setSelectedTags] = React.useState([]);
+  const [categories, setCategories] = React.useState([]);
+  const [attachments, setAttachments] = React.useState([]);
+  const [attForm, setAttForm] = React.useState({ categoryId: '', name: '', file: null });
 
   const load = async () => {
     const [nodesRes, tagsRes] = await Promise.all([
@@ -63,7 +66,17 @@ export default function NodeList({ modelId, open, onClose }) {
     setTags(tagsRes.data);
   };
 
-  React.useEffect(() => { if (open) load(); }, [open]);
+  const loadCategories = async () => {
+    const res = await axios.get('/api/document-categories');
+    setCategories(res.data);
+  };
+
+  const loadAttachments = async (id) => {
+    const res = await axios.get(`/api/nodes/${id}/attachments`);
+    setAttachments(res.data);
+  };
+
+  React.useEffect(() => { if (open) { load(); loadCategories(); } }, [open]);
 
   const handleSave = async () => {
     const payload = {
@@ -94,6 +107,7 @@ export default function NodeList({ modelId, open, onClose }) {
     setEditing(node);
     setForm({ name: node.name, parentId: node.parentId || '' });
     setSelectedTags(node.tags ? node.tags.map(t => t.id) : []);
+    loadAttachments(node.id);
     setDialogOpen(true);
   };
 
@@ -101,6 +115,8 @@ export default function NodeList({ modelId, open, onClose }) {
     setEditing(null);
     setForm({ name: '', parentId });
     setSelectedTags([]);
+    setAttachments([]);
+    setAttForm({ categoryId: '', name: '', file: null });
     setDialogOpen(true);
   };
 
@@ -223,6 +239,61 @@ export default function NodeList({ modelId, open, onClose }) {
                 ))}
               </Select>
             </FormControl>
+            {editing && (
+              <>
+                <div style={{ marginTop: '1rem' }}>
+                  <FormControl fullWidth sx={{ mt: 2 }}>
+                    <InputLabel>Categoría *</InputLabel>
+                    <Select
+                      label="Categoría *"
+                      value={attForm.categoryId}
+                      onChange={e => setAttForm({ ...attForm, categoryId: e.target.value })}
+                    >
+                      {categories.map(c => (
+                        <MenuItem key={c.id} value={c.id}>{c.name}</MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                  <TextField
+                    required
+                    label="Nombre fichero *"
+                    value={attForm.name}
+                    onChange={e => setAttForm({ ...attForm, name: e.target.value })}
+                    fullWidth
+                    sx={{ mt: 2 }}
+                  />
+                  <input
+                    type="file"
+                    onChange={e => setAttForm({ ...attForm, file: e.target.files[0] })}
+                    style={{ marginTop: '1rem' }}
+                  />
+                  <Button
+                    onClick={async () => {
+                      if (!attForm.file) return;
+                      const fd = new FormData();
+                      fd.append('file', attForm.file);
+                      fd.append('name', attForm.name);
+                      fd.append('categoryId', attForm.categoryId);
+                      await axios.post(`/api/nodes/${editing.id}/attachments`, fd);
+                      setAttForm({ categoryId: '', name: '', file: null });
+                      loadAttachments(editing.id);
+                    }}
+                    sx={{ mt: 1 }}
+                  >
+                    Subir
+                  </Button>
+                </div>
+                <div style={{ marginTop: '1rem' }}>
+                  {attachments.map(att => (
+                    <div key={att.id} style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
+                      <Chip label={att.DocumentCategory.name} sx={{ mr: 1 }} />
+                      <a href={`/${att.filePath}`} target="_blank" rel="noopener noreferrer">{att.name}</a>
+                      <Button color="error" size="small" sx={{ ml: 1 }} onClick={async () => { if (window.confirm('¿Eliminar archivo?')) { await axios.delete(`/api/attachments/${att.id}`); loadAttachments(editing.id); } }}>Eliminar</Button>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
           </DialogContent>
           <DialogActions>
             <Button onClick={() => setDialogOpen(false)}>Cancelar</Button>

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "express": "^5.1.0",
     "mariadb": "^3.4.2",
     "mysql2": "^3.14.1",
-    "sequelize": "^6.37.7"
+    "sequelize": "^6.37.7",
+    "multer": "^1.4.5-lts.1"
   }
 }


### PR DESCRIPTION
## Summary
- support document categories for attachments
- add category management dialog in admin menu
- allow uploading and listing attachments in node editor
- store uploaded files on server using Multer
- clean up node deletion to remove attachments

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test -- -u` in client *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b295cfa9c8331a28b30ca43f5555b