### PR TITLE
Fix env variable name for database password

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Esta guía explica cómo poner en marcha la aplicación desde cero en un servido
    cat <<'ENV' > .env
    DB_NAME=mcm
    DB_USER=mcm
-   DB_PASS=clave_segura
+   DB_PASSWORD=clave_segura
    DB_HOST=localhost
    ENV
    cd ..

--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,11 @@ const upload = multer({ dest: path.join(__dirname, 'uploads') });
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
 // Database connection
-const sequelize = new Sequelize(process.env.DB_NAME || 'mcm', process.env.DB_USER || 'root', process.env.DB_PASS || '', {
+const sequelize = new Sequelize(
+  process.env.DB_NAME || 'mcm',
+  process.env.DB_USER || 'root',
+  process.env.DB_PASSWORD || '',
+  {
   host: process.env.DB_HOST || 'localhost',
   dialect: 'mariadb'
 });


### PR DESCRIPTION
## Summary
- make sure the API reads `DB_PASSWORD` from `.env`
- update README to reflect new variable name

## Testing
- `npm test --silent` within `client` (no tests found)
- `npm test --silent` within `server` (no tests run)


------
https://chatgpt.com/codex/tasks/task_e_684c71fe68348331b9f7387b1ea0d3c8