### PR TITLE
Update vite server host

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Esta guía explica cómo poner en marcha la aplicación desde cero en un servido
    cd client
    npm start
    ```
-   React abrirá un servidor de desarrollo en `http://localhost:3000` con recarga automática.
-
+  React abrirá un servidor de desarrollo accesible desde otras máquinas en `http://<IP_DEL_SERVIDOR>:3000` con recarga automática.
+  
 ## Despliegue definitivo
 
 1. **Construir el cliente**

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: true,
     proxy: {
       '/api': 'http://localhost:3001'
     }


### PR DESCRIPTION
## Summary
- make Vite dev server listen on all interfaces
- document new host so the client can be accessed remotely

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c7e1c2c9483318751543699f8b68b