### PR TITLE
Fix DB startup retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ Esta guía explica cómo poner en marcha la aplicación desde cero en un servido
    npm start
    ```
    La API quedará accesible en `http://localhost:3001`.
+   Si la base de datos aún no está disponible, el servidor reintentará la conexión unas veces antes de abortar.
 2. **Iniciar el cliente**
    En otra terminal:
    ```bash
    cd client
-   npm start
+   npm run dev
    ```
    React abrirá un servidor de desarrollo en `http://localhost:3000` con recarga automática.
 


### PR DESCRIPTION
## Summary
- add retry logic to initDatabase to handle transient DB startup issues
- mention the retry behavior in README

## Testing
- `npm run --silent start` *(fails: ConnectionRefusedError after retries)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684c7ea3f08c833182809960b72c5f35