### PR TITLE
Fix node creation error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -93,6 +93,7 @@ const Node = sequelize.define('Node', {
   order: {
     type: DataTypes.INTEGER,
     allowNull: false,
+    defaultValue: 0,
   },
   modelId: {
     type: DataTypes.INTEGER,


### PR DESCRIPTION
## Summary
- default Node order to 0 so models can be created without errors

## Testing
- `npm install` *(fails: Database connection not configured)*

------
https://chatgpt.com/codex/tasks/task_e_684c8558fc248331a265af26949913f1