### PR TITLE
Replace admin submenus with tabs

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import Header from './components/Header';
 import ModelList from './components/ModelList';
-import ParameterList from './components/ParameterList';
-import DocumentCategoryList from './components/DocumentCategoryList';
+import AdminPage from './components/AdminPage';
 import axios from 'axios';
 import Container from '@mui/material/Container';
 
 function App() {
-  const [showModels, setShowModels] = React.useState(false);
+  const [showAdmin, setShowAdmin] = React.useState(false);
   const [showPublicModels, setShowPublicModels] = React.useState(false);
-  const [showParams, setShowParams] = React.useState(false);
-  const [showCats, setShowCats] = React.useState(false);
   const [appName, setAppName] = React.useState('MCM');
 
   const loadName = async () => {
@@ -25,20 +22,16 @@ function App() {
 
   React.useEffect(() => { loadName(); }, []);
 
-  const closeAll = () => { setShowModels(false); setShowParams(false); setShowPublicModels(false); setShowCats(false); };
+  const closeAll = () => { setShowAdmin(false); setShowPublicModels(false); };
 
   return (
     <div>
       <Header appName={appName}
               onModels={() => { closeAll(); setShowPublicModels(true); }}
-              onAdmin={() => { closeAll(); setShowModels(true); }}
-              onCategories={() => { closeAll(); setShowCats(true); }}
-              onParams={() => { closeAll(); setShowParams(true); }} />
+              onAdmin={() => { closeAll(); setShowAdmin(true); }} />
       <Container sx={{ mt: 2 }}>
         {showPublicModels && <ModelList readOnly initialView="cards" />}
-        {showModels && <ModelList />}
-        {showCats && <DocumentCategoryList open={showCats} onClose={() => setShowCats(false)} />}
-        {showParams && <ParameterList />}
+        {showAdmin && <AdminPage />}
       </Container>
     </div>
   );

--- a/client/src/components/AdminPage.jsx
+++ b/client/src/components/AdminPage.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import Box from '@mui/material/Box';
+import ModelList from './ModelList';
+import DocumentCategoryList from './DocumentCategoryList';
+import ParameterList from './ParameterList';
+
+export default function AdminPage() {
+  const [tab, setTab] = React.useState(0);
+  return (
+    <Box>
+      <Tabs value={tab} onChange={(e, v) => setTab(v)} sx={{ mb: 2 }}>
+        <Tab label="Modelos" />
+        <Tab label="Categorías" />
+        <Tab label="Parámetros" />
+      </Tabs>
+      {tab === 0 && <ModelList />}
+      {tab === 1 && <DocumentCategoryList />}
+      {tab === 2 && <ParameterList />}
+    </Box>
+  );
+}

--- a/client/src/components/DocumentCategoryList.jsx
+++ b/client/src/components/DocumentCategoryList.jsx
@@ -61,7 +61,7 @@ export default function DocumentCategoryList({ open, onClose }) {
     setCats(res.data);
   };
 
-  React.useEffect(() => { if (open) load(); }, [open]);
+  React.useEffect(() => { if (open === undefined || open) load(); }, [open]);
 
   const handleSave = async () => {
     if (editing) {
@@ -110,74 +110,87 @@ export default function DocumentCategoryList({ open, onClose }) {
     setSort(prev => ({ key, dir: prev.key === key && prev.dir === 'asc' ? 'desc' : 'asc' }));
   };
 
-  return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>Categorías de documento</DialogTitle>
-      <DialogContent>
-        <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>Cambiar vista</Button>
-        <Button onClick={openCreate}>Nueva</Button>
-        <Button onClick={() => csvExport(cats)}>Exportar CSV</Button>
-        <Button onClick={() => pdfExport(cats)}>Exportar PDF</Button>
-        <IconButton onClick={() => setShowFilters(!showFilters)}>
-          <FilterListIcon />
-        </IconButton>
-        {showFilters && (
-          <div style={{ margin: '1rem 0' }}>
-            <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
-            <Button onClick={() => setFilter('')}>Reset</Button>
-          </div>
-        )}
-        {view === 'table' ? (
-          <TableContainer component={Paper} sx={{ mt: 2 }}>
-            <Table>
-          <TableHead sx={{ backgroundColor: '#f5f5f5' }}>
-            <TableRow>
-                  <TableCell onClick={() => toggleSort('name')} style={{ fontWeight: 'bold' }}>Nombre</TableCell>
-                  <TableCell style={{ fontWeight: 'bold' }}>Acciones</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {sorted.map((cat) => (
-                  <TableRow key={cat.id}>
-                    <TableCell>{cat.name}</TableCell>
-                    <TableCell>
-                      <Button onClick={() => openEdit(cat)}>Editar</Button>
-                      <Button color="error" onClick={() => handleDelete(cat.id)}>Eliminar</Button>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        ) : (
-          <Grid container spacing={2} sx={{ mt: 2 }}>
-            {sorted.map((cat) => (
-              <Grid item xs={12} md={4} key={cat.id}>
-                <Card>
-                  <CardContent>
-                    <Typography variant="h6">{cat.name}</Typography>
+  const content = (
+    <>
+      <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>Cambiar vista</Button>
+      <Button onClick={openCreate}>Nueva</Button>
+      <Button onClick={() => csvExport(cats)}>Exportar CSV</Button>
+      <Button onClick={() => pdfExport(cats)}>Exportar PDF</Button>
+      <IconButton onClick={() => setShowFilters(!showFilters)}>
+        <FilterListIcon />
+      </IconButton>
+      {showFilters && (
+        <div style={{ margin: '1rem 0' }}>
+          <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
+          <Button onClick={() => setFilter('')}>Reset</Button>
+        </div>
+      )}
+      {view === 'table' ? (
+        <TableContainer component={Paper} sx={{ mt: 2 }}>
+          <Table>
+            <TableHead sx={{ backgroundColor: '#f5f5f5' }}>
+              <TableRow>
+                <TableCell onClick={() => toggleSort('name')} style={{ fontWeight: 'bold' }}>Nombre</TableCell>
+                <TableCell style={{ fontWeight: 'bold' }}>Acciones</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {sorted.map((cat) => (
+                <TableRow key={cat.id}>
+                  <TableCell>{cat.name}</TableCell>
+                  <TableCell>
                     <Button onClick={() => openEdit(cat)}>Editar</Button>
                     <Button color="error" onClick={() => handleDelete(cat.id)}>Eliminar</Button>
-                  </CardContent>
-                </Card>
-              </Grid>
-            ))}
-          </Grid>
-        )}
-        <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
-          <DialogTitle>{editing ? 'Editar' : 'Nueva'} categoría</DialogTitle>
-          <DialogContent>
-            <TextField required label="Nombre *" value={form.name} onChange={(e) => setForm({ name: e.target.value })} fullWidth />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setDialogOpen(false)}>Cancelar</Button>
-            <Button onClick={handleSave}>Guardar</Button>
-          </DialogActions>
-        </Dialog>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cerrar</Button>
-      </DialogActions>
-    </Dialog>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      ) : (
+        <Grid container spacing={2} sx={{ mt: 2 }}>
+          {sorted.map((cat) => (
+            <Grid item xs={12} md={4} key={cat.id}>
+              <Card>
+                <CardContent>
+                  <Typography variant="h6">{cat.name}</Typography>
+                  <Button onClick={() => openEdit(cat)}>Editar</Button>
+                  <Button color="error" onClick={() => handleDelete(cat.id)}>Eliminar</Button>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      )}
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
+        <DialogTitle>{editing ? 'Editar' : 'Nueva'} categoría</DialogTitle>
+        <DialogContent>
+          <TextField required label="Nombre *" value={form.name} onChange={(e) => setForm({ name: e.target.value })} fullWidth />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)}>Cancelar</Button>
+          <Button onClick={handleSave}>Guardar</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+
+  if (open !== undefined) {
+    return (
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+        <DialogTitle>Categorías de documento</DialogTitle>
+        <DialogContent>{content}</DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Cerrar</Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
+  return (
+    <div>
+      <Typography variant="h6" sx={{ mb: 2 }}>Categorías de documento</Typography>
+      {content}
+    </div>
   );
 }

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -7,7 +7,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import SettingsIcon from '@mui/icons-material/Settings';
 
-export default function Header({ appName, onAdmin, onParams, onModels, onCategories }) {
+export default function Header({ appName, onAdmin, onModels }) {
   const [anchorEl, setAnchorEl] = React.useState(null);
 
   const handleSettingsClick = (event) => {
@@ -29,9 +29,7 @@ export default function Header({ appName, onAdmin, onParams, onModels, onCategor
           <SettingsIcon />
         </IconButton>
         <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-          <MenuItem onClick={() => { handleClose(); onAdmin(); }}>Gestión de modelos</MenuItem>
-          <MenuItem onClick={() => { handleClose(); onCategories(); }}>Categorías doc</MenuItem>
-          <MenuItem onClick={() => { handleClose(); onParams(); }}>Parámetros</MenuItem>
+          <MenuItem onClick={() => { handleClose(); onAdmin(); }}>Administración</MenuItem>
         </Menu>
       </Toolbar>
     </AppBar>


### PR DESCRIPTION
## Summary
- add an AdminPage component with tabs for Models, Categories and Parameters
- refactor DocumentCategoryList to work as dialog or page
- update Header to only link to admin page instead of each sub menu
- update App to show AdminPage and adjust navigation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8585961c8331a77468951185bb21