### PR TITLE
Disable parameter deletion

### DIFF
--- a/client/src/components/ParameterList.jsx
+++ b/client/src/components/ParameterList.jsx
@@ -75,12 +75,6 @@ export default function ParameterList() {
     load();
   };
 
-  const handleDelete = async (id) => {
-    if (window.confirm('¿Eliminar elemento?')) {
-      await axios.delete(`/api/parameters/${id}`);
-      load();
-    }
-  };
 
   const handleReset = async (id) => {
     await axios.post(`/api/parameters/${id}/reset`);
@@ -153,7 +147,6 @@ export default function ParameterList() {
                   <TableCell>
                     <Button onClick={() => openEdit(param)}>Editar</Button>
                     <Button color="secondary" onClick={() => handleReset(param.id)}>Reset</Button>
-                    <Button color="error" onClick={() => handleDelete(param.id)}>Eliminar</Button>
                   </TableCell>
                 </TableRow>
               ))}
@@ -171,7 +164,6 @@ export default function ParameterList() {
                   <Typography variant="caption">Por defecto: {param.defaultValue}</Typography>
                   <Button onClick={() => openEdit(param)}>Editar</Button>
                   <Button color="secondary" onClick={() => handleReset(param.id)}>Reset</Button>
-                  <Button color="error" onClick={() => handleDelete(param.id)}>Eliminar</Button>
                 </CardContent>
               </Card>
             </Grid>

--- a/server/index.js
+++ b/server/index.js
@@ -250,8 +250,7 @@ app.post('/api/parameters/:id/reset', async (req, res) => {
 });
 
 app.delete('/api/parameters/:id', async (req, res) => {
-  await Parameter.destroy({ where: { id: req.params.id } });
-  res.json({});
+  res.status(405).json({ error: 'Eliminar parámetros no permitido' });
 });
 
 // Document category routes


### PR DESCRIPTION
## Summary
- remove delete button from parameters UI
- disallow DELETE /api/parameters/:id on server

## Testing
- `npm run build` in `client`
- `npm start` in `server` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_684c8626b7d48331babf5bd8c6b51c97