### PR TITLE
Update document category list view

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -37,7 +37,7 @@ function App() {
       <Container sx={{ mt: 2 }}>
         {showPublicModels && <ModelList readOnly initialView="cards" />}
         {showModels && <ModelList />}
-        {showCats && <DocumentCategoryList open={showCats} onClose={() => setShowCats(false)} />}
+        {showCats && <DocumentCategoryList />}
         {showParams && <ParameterList />}
       </Container>
     </div>

--- a/client/src/components/DocumentCategoryList.jsx
+++ b/client/src/components/DocumentCategoryList.jsx
@@ -46,7 +46,7 @@ function pdfExport(data) {
   doc.save('categorias.pdf');
 }
 
-export default function DocumentCategoryList({ open, onClose }) {
+export default function DocumentCategoryList() {
   const [cats, setCats] = React.useState([]);
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [editing, setEditing] = React.useState(null);
@@ -61,7 +61,7 @@ export default function DocumentCategoryList({ open, onClose }) {
     setCats(res.data);
   };
 
-  React.useEffect(() => { if (open) load(); }, [open]);
+  React.useEffect(() => { load(); }, []);
 
   const handleSave = async () => {
     if (editing) {
@@ -111,9 +111,8 @@ export default function DocumentCategoryList({ open, onClose }) {
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>Categorías de documento</DialogTitle>
-      <DialogContent>
+    <div>
+      <Typography variant="h6" sx={{ mb: 2 }}>Categoría de documento</Typography>
         <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>Cambiar vista</Button>
         <Button onClick={openCreate}>Nueva</Button>
         <Button onClick={() => csvExport(cats)}>Exportar CSV</Button>
@@ -174,10 +173,6 @@ export default function DocumentCategoryList({ open, onClose }) {
             <Button onClick={handleSave}>Guardar</Button>
           </DialogActions>
         </Dialog>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cerrar</Button>
-      </DialogActions>
-    </Dialog>
+    </div>
   );
 }

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -30,7 +30,7 @@ export default function Header({ appName, onAdmin, onParams, onModels, onCategor
         </IconButton>
         <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
           <MenuItem onClick={() => { handleClose(); onAdmin(); }}>Gestión de modelos</MenuItem>
-          <MenuItem onClick={() => { handleClose(); onCategories(); }}>Categorías doc</MenuItem>
+          <MenuItem onClick={() => { handleClose(); onCategories(); }}>Categoría de documento</MenuItem>
           <MenuItem onClick={() => { handleClose(); onParams(); }}>Parámetros</MenuItem>
         </Menu>
       </Toolbar>


### PR DESCRIPTION
## Summary
- rename menu option to "Categoría de documento"
- show the document category list directly in the main window

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c867f681c833184c639973c207cdf