### PR TITLE
Icon-only action buttons with tooltips

### DIFF
--- a/client/src/components/DocumentCategoryList.jsx
+++ b/client/src/components/DocumentCategoryList.jsx
@@ -18,7 +18,16 @@ import Typography from '@mui/material/Typography';
 import CardContent from '@mui/material/CardContent';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import AddIcon from '@mui/icons-material/Add';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import TableRowsIcon from '@mui/icons-material/TableRows';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import { jsPDF } from 'jspdf';
 
 function csvExport(data) {
@@ -114,18 +123,40 @@ export default function DocumentCategoryList({ open, onClose }) {
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
       <DialogTitle>Categorías de documento</DialogTitle>
       <DialogContent>
-        <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>Cambiar vista</Button>
-        <Button onClick={openCreate}>Nueva</Button>
-        <Button onClick={() => csvExport(cats)}>Exportar CSV</Button>
-        <Button onClick={() => pdfExport(cats)}>Exportar PDF</Button>
-        <IconButton onClick={() => setShowFilters(!showFilters)}>
-          <FilterListIcon />
-        </IconButton>
+        <Tooltip title={view === 'table' ? 'Vista tarjetas' : 'Vista tabla'}>
+          <IconButton onClick={() => setView(view === 'table' ? 'cards' : 'table')}>
+            {view === 'table' ? <ViewModuleIcon /> : <TableRowsIcon />}
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Nueva">
+          <IconButton onClick={openCreate}>
+            <AddIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar CSV">
+          <IconButton onClick={() => csvExport(cats)}>
+            <FileDownloadIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar PDF">
+          <IconButton onClick={() => pdfExport(cats)}>
+            <PictureAsPdfIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Filtros">
+          <IconButton onClick={() => setShowFilters(!showFilters)}>
+            <FilterListIcon />
+          </IconButton>
+        </Tooltip>
         {showFilters && (
           <div style={{ margin: '1rem 0' }}>
-            <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
-            <Button onClick={() => setFilter('')}>Reset</Button>
-          </div>
+          <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
+          <Tooltip title="Reset">
+            <IconButton onClick={() => setFilter('')}>
+              <RestartAltIcon />
+            </IconButton>
+          </Tooltip>
+        </div>
         )}
         {view === 'table' ? (
           <TableContainer component={Paper} sx={{ mt: 2 }}>
@@ -141,8 +172,16 @@ export default function DocumentCategoryList({ open, onClose }) {
                   <TableRow key={cat.id}>
                     <TableCell>{cat.name}</TableCell>
                     <TableCell>
-                      <Button onClick={() => openEdit(cat)}>Editar</Button>
-                      <Button color="error" onClick={() => handleDelete(cat.id)}>Eliminar</Button>
+                      <Tooltip title="Editar">
+                        <IconButton onClick={() => openEdit(cat)}>
+                          <EditIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Eliminar">
+                        <IconButton color="error" onClick={() => handleDelete(cat.id)}>
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -156,8 +195,16 @@ export default function DocumentCategoryList({ open, onClose }) {
                 <Card>
                   <CardContent>
                     <Typography variant="h6">{cat.name}</Typography>
-                    <Button onClick={() => openEdit(cat)}>Editar</Button>
-                    <Button color="error" onClick={() => handleDelete(cat.id)}>Eliminar</Button>
+                    <Tooltip title="Editar">
+                      <IconButton onClick={() => openEdit(cat)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar">
+                      <IconButton color="error" onClick={() => handleDelete(cat.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
                   </CardContent>
                 </Card>
               </Grid>

--- a/client/src/components/ModelList.jsx
+++ b/client/src/components/ModelList.jsx
@@ -18,11 +18,23 @@ import Typography from "@mui/material/Typography";
 import CardContent from '@mui/material/CardContent';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import AddIcon from '@mui/icons-material/Add';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import TableRowsIcon from '@mui/icons-material/TableRows';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import LabelIcon from '@mui/icons-material/Label';
+import GroupsIcon from '@mui/icons-material/Groups';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import { jsPDF } from 'jspdf';
 import TagList from './TagList';
 import TeamList from './TeamList';
@@ -146,20 +158,42 @@ export default function ModelList({ readOnly = false, initialView = 'table' }) {
   return (
     <div>
       {!readOnly && (
-        <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>
-          Cambiar vista
-        </Button>
+        <Tooltip title={view === 'table' ? 'Vista tarjetas' : 'Vista tabla'}>
+          <IconButton onClick={() => setView(view === 'table' ? 'cards' : 'table')}>
+            {view === 'table' ? <ViewModuleIcon /> : <TableRowsIcon />}
+          </IconButton>
+        </Tooltip>
       )}
-      {!readOnly && <Button onClick={openCreate}>Nuevo</Button>}
-      <Button onClick={() => csvExport(models)}>Exportar CSV</Button>
-      <Button onClick={() => pdfExport(models)}>Exportar PDF</Button>
-      <IconButton onClick={() => setShowFilters(!showFilters)}>
-        <FilterListIcon />
-      </IconButton>
+      {!readOnly && (
+        <Tooltip title="Nuevo">
+          <IconButton onClick={openCreate}>
+            <AddIcon />
+          </IconButton>
+        </Tooltip>
+      )}
+      <Tooltip title="Exportar CSV">
+        <IconButton onClick={() => csvExport(models)}>
+          <FileDownloadIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Exportar PDF">
+        <IconButton onClick={() => pdfExport(models)}>
+          <PictureAsPdfIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Filtros">
+        <IconButton onClick={() => setShowFilters(!showFilters)}>
+          <FilterListIcon />
+        </IconButton>
+      </Tooltip>
       {showFilters && (
         <div style={{ margin: '1rem 0' }}>
           <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
-          <Button onClick={() => setFilter('')}>Reset</Button>
+          <Tooltip title="Reset">
+            <IconButton onClick={() => setFilter('')}>
+              <RestartAltIcon />
+            </IconButton>
+          </Tooltip>
         </div>
       )}
       {view === 'table' ? (
@@ -179,11 +213,31 @@ export default function ModelList({ readOnly = false, initialView = 'table' }) {
                   <TableCell>{model.author}</TableCell>
                   {!readOnly && (
                     <TableCell>
-                      <Button onClick={() => openEdit(model)}>Editar</Button>
-                      <Button onClick={() => openTags(model)}>Tags</Button>
-                      <Button onClick={() => openTeams(model)}>Equipos</Button>
-                      <Button onClick={() => openNodes(model)}>Nodos</Button>
-                      <Button color="error" onClick={() => handleDelete(model.id)}>Eliminar</Button>
+                      <Tooltip title="Editar">
+                        <IconButton onClick={() => openEdit(model)}>
+                          <EditIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Tags">
+                        <IconButton onClick={() => openTags(model)}>
+                          <LabelIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Equipos">
+                        <IconButton onClick={() => openTeams(model)}>
+                          <GroupsIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Nodos">
+                        <IconButton onClick={() => openNodes(model)}>
+                          <AccountTreeIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Eliminar">
+                        <IconButton color="error" onClick={() => handleDelete(model.id)}>
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
                     </TableCell>
                   )}
                 </TableRow>
@@ -201,11 +255,31 @@ export default function ModelList({ readOnly = false, initialView = 'table' }) {
                   <Typography>{model.author}</Typography>
                   {!readOnly && (
                     <>
-                      <Button onClick={() => openEdit(model)}>Editar</Button>
-                      <Button onClick={() => openTags(model)}>Tags</Button>
-                      <Button onClick={() => openTeams(model)}>Equipos</Button>
-                      <Button onClick={() => openNodes(model)}>Nodos</Button>
-                      <Button color="error" onClick={() => handleDelete(model.id)}>Eliminar</Button>
+                      <Tooltip title="Editar">
+                        <IconButton onClick={() => openEdit(model)}>
+                          <EditIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Tags">
+                        <IconButton onClick={() => openTags(model)}>
+                          <LabelIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Equipos">
+                        <IconButton onClick={() => openTeams(model)}>
+                          <GroupsIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Nodos">
+                        <IconButton onClick={() => openNodes(model)}>
+                          <AccountTreeIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Eliminar">
+                        <IconButton color="error" onClick={() => handleDelete(model.id)}>
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
                     </>
                   )}
                 </CardContent>

--- a/client/src/components/NodeList.jsx
+++ b/client/src/components/NodeList.jsx
@@ -11,7 +11,15 @@ import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import AddIcon from '@mui/icons-material/Add';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import Chip from '@mui/material/Chip';
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -178,16 +186,26 @@ export default function NodeList({ modelId, open, onClose }) {
                   {tag.name}
                 </span>
               ))}
-              <Button size="small" onClick={() => openCreate(n.id)}>Añadir</Button>
-              <Button size="small" onClick={() => openEdit(n)}>Editar</Button>
-              <Button
-                size="small"
-                color="error"
-                onClick={() => handleDelete(n.id)}
-                disabled={n.name === 'Raiz' && n.parentId === null}
-              >
-                Eliminar
-              </Button>
+              <Tooltip title="Añadir">
+                <IconButton size="small" onClick={() => openCreate(n.id)}>
+                  <AddIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Editar">
+                <IconButton size="small" onClick={() => openEdit(n)}>
+                  <EditIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Eliminar">
+                <IconButton
+                  size="small"
+                  color="error"
+                  onClick={() => handleDelete(n.id)}
+                  disabled={n.name === 'Raiz' && n.parentId === null}
+                >
+                  <DeleteIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
             </div>
           }
         >
@@ -200,17 +218,35 @@ export default function NodeList({ modelId, open, onClose }) {
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
       <DialogTitle>Nodos</DialogTitle>
       <DialogContent>
-        <Button onClick={() => openCreate('')}>Nuevo nodo raíz</Button>
-        <Button onClick={() => csvExport(nodes)}>Exportar CSV</Button>
-        <Button onClick={() => pdfExport(nodes)}>Exportar PDF</Button>
-        <IconButton onClick={() => setShowFilters(!showFilters)}>
-          <FilterListIcon />
-        </IconButton>
+        <Tooltip title="Nuevo nodo raíz">
+          <IconButton onClick={() => openCreate('')}>
+            <AddIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar CSV">
+          <IconButton onClick={() => csvExport(nodes)}>
+            <FileDownloadIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar PDF">
+          <IconButton onClick={() => pdfExport(nodes)}>
+            <PictureAsPdfIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Filtros">
+          <IconButton onClick={() => setShowFilters(!showFilters)}>
+            <FilterListIcon />
+          </IconButton>
+        </Tooltip>
         {showFilters && (
           <div style={{ margin: '1rem 0' }}>
-            <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
-            <Button onClick={() => setFilter('')}>Reset</Button>
-          </div>
+          <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
+          <Tooltip title="Reset">
+            <IconButton onClick={() => setFilter('')}>
+              <RestartAltIcon />
+            </IconButton>
+          </Tooltip>
+        </div>
         )}
         <TreeView
           defaultCollapseIcon={<ExpandMoreIcon />}
@@ -383,7 +419,11 @@ export default function NodeList({ modelId, open, onClose }) {
                     <div key={att.id} style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
                       <Chip label={att.DocumentCategory.name} sx={{ mr: 1 }} />
                       <a href={`/${att.filePath}`} target="_blank" rel="noopener noreferrer">{att.name}</a>
-                      <Button color="error" size="small" sx={{ ml: 1 }} onClick={async () => { if (window.confirm('¿Eliminar archivo?')) { await axios.delete(`/api/attachments/${att.id}`); loadAttachments(editing.id); } }}>Eliminar</Button>
+                      <Tooltip title="Eliminar archivo">
+                        <IconButton color="error" size="small" sx={{ ml: 1 }} onClick={async () => { if (window.confirm('¿Eliminar archivo?')) { await axios.delete(`/api/attachments/${att.id}`); loadAttachments(editing.id); } }}>
+                          <DeleteIcon fontSize="inherit" />
+                        </IconButton>
+                      </Tooltip>
                     </div>
                   ))}
                 </div>

--- a/client/src/components/ParameterList.jsx
+++ b/client/src/components/ParameterList.jsx
@@ -18,7 +18,17 @@ import Typography from "@mui/material/Typography";
 import CardContent from '@mui/material/CardContent';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import AddIcon from '@mui/icons-material/Add';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import TableRowsIcon from '@mui/icons-material/TableRows';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import RestoreIcon from '@mui/icons-material/Restore';
 import { jsPDF } from 'jspdf';
 
 function csvExport(data) {
@@ -118,19 +128,39 @@ export default function ParameterList() {
 
   return (
     <div>
-      <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>
-        Cambiar vista
-      </Button>
-      <Button onClick={openCreate}>Nuevo</Button>
-      <Button onClick={() => csvExport(params)}>Exportar CSV</Button>
-      <Button onClick={() => pdfExport(params)}>Exportar PDF</Button>
-      <IconButton onClick={() => setShowFilters(!showFilters)}>
-        <FilterListIcon />
-      </IconButton>
+      <Tooltip title={view === 'table' ? 'Vista tarjetas' : 'Vista tabla'}>
+        <IconButton onClick={() => setView(view === 'table' ? 'cards' : 'table')}>
+          {view === 'table' ? <ViewModuleIcon /> : <TableRowsIcon />}
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Nuevo">
+        <IconButton onClick={openCreate}>
+          <AddIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Exportar CSV">
+        <IconButton onClick={() => csvExport(params)}>
+          <FileDownloadIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Exportar PDF">
+        <IconButton onClick={() => pdfExport(params)}>
+          <PictureAsPdfIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Filtros">
+        <IconButton onClick={() => setShowFilters(!showFilters)}>
+          <FilterListIcon />
+        </IconButton>
+      </Tooltip>
       {showFilters && (
         <div style={{ margin: '1rem 0' }}>
           <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
-          <Button onClick={() => setFilter('')}>Reset</Button>
+          <Tooltip title="Reset">
+            <IconButton onClick={() => setFilter('')}>
+              <RestartAltIcon />
+            </IconButton>
+          </Tooltip>
         </div>
       )}
       {view === 'table' ? (
@@ -151,9 +181,21 @@ export default function ParameterList() {
                   <TableCell>{param.value}</TableCell>
                   <TableCell>{param.defaultValue}</TableCell>
                   <TableCell>
-                    <Button onClick={() => openEdit(param)}>Editar</Button>
-                    <Button color="secondary" onClick={() => handleReset(param.id)}>Reset</Button>
-                    <Button color="error" onClick={() => handleDelete(param.id)}>Eliminar</Button>
+                    <Tooltip title="Editar">
+                      <IconButton onClick={() => openEdit(param)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Reset">
+                      <IconButton color="secondary" onClick={() => handleReset(param.id)}>
+                        <RestoreIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar">
+                      <IconButton color="error" onClick={() => handleDelete(param.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
                   </TableCell>
                 </TableRow>
               ))}
@@ -169,9 +211,21 @@ export default function ParameterList() {
                   <Typography variant="h6">{param.name}</Typography>
                   <Typography>{param.value}</Typography>
                   <Typography variant="caption">Por defecto: {param.defaultValue}</Typography>
-                  <Button onClick={() => openEdit(param)}>Editar</Button>
-                  <Button color="secondary" onClick={() => handleReset(param.id)}>Reset</Button>
-                  <Button color="error" onClick={() => handleDelete(param.id)}>Eliminar</Button>
+                  <Tooltip title="Editar">
+                    <IconButton onClick={() => openEdit(param)}>
+                      <EditIcon />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Reset">
+                    <IconButton color="secondary" onClick={() => handleReset(param.id)}>
+                      <RestoreIcon />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Eliminar">
+                    <IconButton color="error" onClick={() => handleDelete(param.id)}>
+                      <DeleteIcon />
+                    </IconButton>
+                  </Tooltip>
                 </CardContent>
               </Card>
             </Grid>

--- a/client/src/components/RoleList.jsx
+++ b/client/src/components/RoleList.jsx
@@ -18,7 +18,16 @@ import Typography from "@mui/material/Typography";
 import CardContent from '@mui/material/CardContent';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import AddIcon from '@mui/icons-material/Add';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import TableRowsIcon from '@mui/icons-material/TableRows';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import { jsPDF } from 'jspdf';
 
 function csvExport(data) {
@@ -114,18 +123,40 @@ export default function RoleList({ teamId, open, onClose }) {
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
       <DialogTitle>Roles</DialogTitle>
       <DialogContent>
-        <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>Cambiar vista</Button>
-        <Button onClick={openCreate}>Nuevo</Button>
-        <Button onClick={() => csvExport(roles)}>Exportar CSV</Button>
-        <Button onClick={() => pdfExport(roles)}>Exportar PDF</Button>
-        <IconButton onClick={() => setShowFilters(!showFilters)}>
-          <FilterListIcon />
-        </IconButton>
+        <Tooltip title={view === 'table' ? 'Vista tarjetas' : 'Vista tabla'}>
+          <IconButton onClick={() => setView(view === 'table' ? 'cards' : 'table')}>
+            {view === 'table' ? <ViewModuleIcon /> : <TableRowsIcon />}
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Nuevo">
+          <IconButton onClick={openCreate}>
+            <AddIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar CSV">
+          <IconButton onClick={() => csvExport(roles)}>
+            <FileDownloadIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar PDF">
+          <IconButton onClick={() => pdfExport(roles)}>
+            <PictureAsPdfIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Filtros">
+          <IconButton onClick={() => setShowFilters(!showFilters)}>
+            <FilterListIcon />
+          </IconButton>
+        </Tooltip>
         {showFilters && (
           <div style={{ margin: '1rem 0' }}>
-            <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
-            <Button onClick={() => setFilter('')}>Reset</Button>
-          </div>
+          <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
+          <Tooltip title="Reset">
+            <IconButton onClick={() => setFilter('')}>
+              <RestartAltIcon />
+            </IconButton>
+          </Tooltip>
+        </div>
         )}
         {view === 'table' ? (
           <TableContainer component={Paper} sx={{ mt: 2 }}>
@@ -143,8 +174,16 @@ export default function RoleList({ teamId, open, onClose }) {
                     <TableCell>{role.order}</TableCell>
                     <TableCell>{role.name}</TableCell>
                     <TableCell>
-                      <Button onClick={() => openEdit(role)}>Editar</Button>
-                      <Button color="error" onClick={() => handleDelete(role.id)}>Eliminar</Button>
+                      <Tooltip title="Editar">
+                        <IconButton onClick={() => openEdit(role)}>
+                          <EditIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Eliminar">
+                        <IconButton color="error" onClick={() => handleDelete(role.id)}>
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -158,8 +197,16 @@ export default function RoleList({ teamId, open, onClose }) {
                 <Card>
                   <CardContent>
                     <Typography variant="h6">{role.order} - {role.name}</Typography>
-                    <Button onClick={() => openEdit(role)}>Editar</Button>
-                    <Button color="error" onClick={() => handleDelete(role.id)}>Eliminar</Button>
+                    <Tooltip title="Editar">
+                      <IconButton onClick={() => openEdit(role)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar">
+                      <IconButton color="error" onClick={() => handleDelete(role.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
                   </CardContent>
                 </Card>
               </Grid>

--- a/client/src/components/TagList.jsx
+++ b/client/src/components/TagList.jsx
@@ -18,7 +18,16 @@ import Typography from "@mui/material/Typography";
 import CardContent from '@mui/material/CardContent';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import AddIcon from '@mui/icons-material/Add';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import TableRowsIcon from '@mui/icons-material/TableRows';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import { jsPDF } from 'jspdf';
 
 function csvExport(data) {
@@ -114,18 +123,40 @@ export default function TagList({ modelId, open, onClose }) {
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
       <DialogTitle>Etiquetas</DialogTitle>
       <DialogContent>
-        <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>Cambiar vista</Button>
-        <Button onClick={openCreate}>Nueva</Button>
-        <Button onClick={() => csvExport(tags)}>Exportar CSV</Button>
-        <Button onClick={() => pdfExport(tags)}>Exportar PDF</Button>
-        <IconButton onClick={() => setShowFilters(!showFilters)}>
-          <FilterListIcon />
-        </IconButton>
+        <Tooltip title={view === 'table' ? 'Vista tarjetas' : 'Vista tabla'}>
+          <IconButton onClick={() => setView(view === 'table' ? 'cards' : 'table')}>
+            {view === 'table' ? <ViewModuleIcon /> : <TableRowsIcon />}
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Nueva">
+          <IconButton onClick={openCreate}>
+            <AddIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar CSV">
+          <IconButton onClick={() => csvExport(tags)}>
+            <FileDownloadIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar PDF">
+          <IconButton onClick={() => pdfExport(tags)}>
+            <PictureAsPdfIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Filtros">
+          <IconButton onClick={() => setShowFilters(!showFilters)}>
+            <FilterListIcon />
+          </IconButton>
+        </Tooltip>
         {showFilters && (
           <div style={{ margin: '1rem 0' }}>
-            <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
-            <Button onClick={() => setFilter('')}>Reset</Button>
-          </div>
+          <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
+          <Tooltip title="Reset">
+            <IconButton onClick={() => setFilter('')}>
+              <RestartAltIcon />
+            </IconButton>
+          </Tooltip>
+        </div>
         )}
         {view === 'table' ? (
           <TableContainer component={Paper} sx={{ mt: 2 }}>
@@ -149,8 +180,16 @@ export default function TagList({ modelId, open, onClose }) {
                     </TableCell>
                     <TableCell>{tag.textColor}</TableCell>
                     <TableCell>
-                      <Button onClick={() => openEdit(tag)}>Editar</Button>
-                      <Button color="error" onClick={() => handleDelete(tag.id)}>Eliminar</Button>
+                      <Tooltip title="Editar">
+                        <IconButton onClick={() => openEdit(tag)}>
+                          <EditIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Eliminar">
+                        <IconButton color="error" onClick={() => handleDelete(tag.id)}>
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -167,8 +206,16 @@ export default function TagList({ modelId, open, onClose }) {
                     <div style={{ backgroundColor: tag.bgColor, color: tag.textColor, padding: '0.5rem' }}>
                       {tag.name}
                     </div>
-                    <Button onClick={() => openEdit(tag)}>Editar</Button>
-                    <Button color="error" onClick={() => handleDelete(tag.id)}>Eliminar</Button>
+                    <Tooltip title="Editar">
+                      <IconButton onClick={() => openEdit(tag)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar">
+                      <IconButton color="error" onClick={() => handleDelete(tag.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
                   </CardContent>
                 </Card>
               </Grid>

--- a/client/src/components/TeamList.jsx
+++ b/client/src/components/TeamList.jsx
@@ -18,7 +18,17 @@ import Typography from "@mui/material/Typography";
 import CardContent from '@mui/material/CardContent';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import AddIcon from '@mui/icons-material/Add';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import TableRowsIcon from '@mui/icons-material/TableRows';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import GroupIcon from '@mui/icons-material/Group';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import { jsPDF } from 'jspdf';
 import RoleList from './RoleList';
 
@@ -120,18 +130,40 @@ export default function TeamList({ modelId, open, onClose }) {
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
       <DialogTitle>Equipos</DialogTitle>
       <DialogContent>
-        <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>Cambiar vista</Button>
-        <Button onClick={openCreate}>Nuevo</Button>
-        <Button onClick={() => csvExport(teams)}>Exportar CSV</Button>
-        <Button onClick={() => pdfExport(teams)}>Exportar PDF</Button>
-        <IconButton onClick={() => setShowFilters(!showFilters)}>
-          <FilterListIcon />
-        </IconButton>
+        <Tooltip title={view === 'table' ? 'Vista tarjetas' : 'Vista tabla'}>
+          <IconButton onClick={() => setView(view === 'table' ? 'cards' : 'table')}>
+            {view === 'table' ? <ViewModuleIcon /> : <TableRowsIcon />}
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Nuevo">
+          <IconButton onClick={openCreate}>
+            <AddIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar CSV">
+          <IconButton onClick={() => csvExport(teams)}>
+            <FileDownloadIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar PDF">
+          <IconButton onClick={() => pdfExport(teams)}>
+            <PictureAsPdfIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Filtros">
+          <IconButton onClick={() => setShowFilters(!showFilters)}>
+            <FilterListIcon />
+          </IconButton>
+        </Tooltip>
         {showFilters && (
           <div style={{ margin: '1rem 0' }}>
-            <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
-            <Button onClick={() => setFilter('')}>Reset</Button>
-          </div>
+          <TextField label="Buscar" value={filter} onChange={e => setFilter(e.target.value)} />
+          <Tooltip title="Reset">
+            <IconButton onClick={() => setFilter('')}>
+              <RestartAltIcon />
+            </IconButton>
+          </Tooltip>
+        </div>
         )}
         {view === 'table' ? (
           <TableContainer component={Paper} sx={{ mt: 2 }}>
@@ -149,9 +181,21 @@ export default function TeamList({ modelId, open, onClose }) {
                     <TableCell>{team.order}</TableCell>
                     <TableCell>{team.name}</TableCell>
                     <TableCell>
-                      <Button onClick={() => openEdit(team)}>Editar</Button>
-                      <Button onClick={() => openRoles(team)}>Roles</Button>
-                      <Button color="error" onClick={() => handleDelete(team.id)}>Eliminar</Button>
+                      <Tooltip title="Editar">
+                        <IconButton onClick={() => openEdit(team)}>
+                          <EditIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Roles">
+                        <IconButton onClick={() => openRoles(team)}>
+                          <GroupIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Eliminar">
+                        <IconButton color="error" onClick={() => handleDelete(team.id)}>
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -165,9 +209,21 @@ export default function TeamList({ modelId, open, onClose }) {
                 <Card>
                   <CardContent>
                     <Typography variant="h6">{team.order} - {team.name}</Typography>
-                    <Button onClick={() => openEdit(team)}>Editar</Button>
-                    <Button onClick={() => openRoles(team)}>Roles</Button>
-                    <Button color="error" onClick={() => handleDelete(team.id)}>Eliminar</Button>
+                    <Tooltip title="Editar">
+                      <IconButton onClick={() => openEdit(team)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Roles">
+                      <IconButton onClick={() => openRoles(team)}>
+                        <GroupIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar">
+                      <IconButton color="error" onClick={() => handleDelete(team.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
                   </CardContent>
                 </Card>
               </Grid>


### PR DESCRIPTION
## Summary
- swap text buttons for icon buttons across entity lists
- add tooltips describing each icon action

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8609e3c483319ae64d5aef70eb3e