### PR TITLE
Update team and role labels

### DIFF
--- a/client/src/components/ModelList.jsx
+++ b/client/src/components/ModelList.jsx
@@ -181,7 +181,7 @@ export default function ModelList({ readOnly = false, initialView = 'table' }) {
                     <TableCell>
                       <Button onClick={() => openEdit(model)}>Editar</Button>
                       <Button onClick={() => openTags(model)}>Tags</Button>
-                      <Button onClick={() => openTeams(model)}>Equipos</Button>
+                      <Button onClick={() => openTeams(model)}>Equipos y roles</Button>
                       <Button onClick={() => openNodes(model)}>Nodos</Button>
                       <Button color="error" onClick={() => handleDelete(model.id)}>Eliminar</Button>
                     </TableCell>
@@ -203,7 +203,7 @@ export default function ModelList({ readOnly = false, initialView = 'table' }) {
                     <>
                       <Button onClick={() => openEdit(model)}>Editar</Button>
                       <Button onClick={() => openTags(model)}>Tags</Button>
-                      <Button onClick={() => openTeams(model)}>Equipos</Button>
+                      <Button onClick={() => openTeams(model)}>Equipos y roles</Button>
                       <Button onClick={() => openNodes(model)}>Nodos</Button>
                       <Button color="error" onClick={() => handleDelete(model.id)}>Eliminar</Button>
                     </>

--- a/client/src/components/RoleList.jsx
+++ b/client/src/components/RoleList.jsx
@@ -46,7 +46,7 @@ function pdfExport(data) {
   doc.save('roles.pdf');
 }
 
-export default function RoleList({ teamId, open, onClose }) {
+export default function RoleList({ teamId, teamName, open, onClose }) {
   const [roles, setRoles] = React.useState([]);
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [editing, setEditing] = React.useState(null);
@@ -112,7 +112,7 @@ export default function RoleList({ teamId, open, onClose }) {
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>Roles</DialogTitle>
+      <DialogTitle>{`Roles del equipo ${teamName}`}</DialogTitle>
       <DialogContent>
         <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>Cambiar vista</Button>
         <Button onClick={openCreate}>Nuevo</Button>

--- a/client/src/components/TeamList.jsx
+++ b/client/src/components/TeamList.jsx
@@ -118,7 +118,7 @@ export default function TeamList({ modelId, open, onClose }) {
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>Equipos</DialogTitle>
+      <DialogTitle>Equipos y roles</DialogTitle>
       <DialogContent>
         <Button onClick={() => setView(view === 'table' ? 'cards' : 'table')}>Cambiar vista</Button>
         <Button onClick={openCreate}>Nuevo</Button>
@@ -186,7 +186,7 @@ export default function TeamList({ modelId, open, onClose }) {
           </DialogActions>
         </Dialog>
         {rolesTeam && (
-          <RoleList open={!!rolesTeam} teamId={rolesTeam.id} onClose={() => setRolesTeam(null)} />
+          <RoleList open={!!rolesTeam} teamId={rolesTeam.id} teamName={rolesTeam.name} onClose={() => setRolesTeam(null)} />
         )}
       </DialogContent>
       <DialogActions>


### PR DESCRIPTION
## Summary
- rename the model menu buttons to **Equipos y roles**
- show **Equipos y roles** in team list dialog
- display the team name in the roles dialog title

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c870c0c688331ba6a9b1105f0e461