### PR TITLE
Fix header menu and remove undefined states

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -31,9 +31,6 @@ function App() {
               onAdmin={() => { closeAll(); setShowAdmin(true); }} />
       <Container sx={{ mt: 2 }}>
         {showPublicModels && <ModelList readOnly initialView="cards" />}
-        {showModels && <ModelList />}
-        {showCats && <DocumentCategoryList />}
-        {showParams && <ParameterList />}
         {showAdmin && <AdminPage />}
 
       </Container>

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -29,9 +29,7 @@ export default function Header({ appName, onAdmin, onModels }) {
           <SettingsIcon />
         </IconButton>
         <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-          <MenuItem onClick={() => { handleClose(); onAdmin(); }}>Gestión de modelos</MenuItem>
-          <MenuItem onClick={() => { handleClose(); onCategories(); }}>Categoría de documento</MenuItem>
-          <MenuItem onClick={() => { handleClose(); onParams(); }}>Parámetros</MenuItem>
+          <MenuItem onClick={() => { handleClose(); onAdmin(); }}>Gestión</MenuItem>
 
         </Menu>
       </Toolbar>


### PR DESCRIPTION
## Summary
- clean up unused `showModels`/`showCats`/`showParams` states
- simplify Header menu to use only existing handlers

## Testing
- `npm test -- -w 0` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c8926f3988331a0dac1cc32f864cd