### PR TITLE
Update team and role UI texts

### DIFF
--- a/client/src/components/ModelList.jsx
+++ b/client/src/components/ModelList.jsx
@@ -223,7 +223,7 @@ export default function ModelList({ readOnly = false, initialView = 'table' }) {
                           <LabelIcon />
                         </IconButton>
                       </Tooltip>
-                      <Tooltip title="Equipos">
+                      <Tooltip title="Equipos y roles">
                         <IconButton onClick={() => openTeams(model)}>
                           <GroupsIcon />
                         </IconButton>
@@ -265,7 +265,7 @@ export default function ModelList({ readOnly = false, initialView = 'table' }) {
                           <LabelIcon />
                         </IconButton>
                       </Tooltip>
-                      <Tooltip title="Equipos">
+                      <Tooltip title="Equipos y roles">
                         <IconButton onClick={() => openTeams(model)}>
                           <GroupsIcon />
                         </IconButton>

--- a/client/src/components/RoleList.jsx
+++ b/client/src/components/RoleList.jsx
@@ -55,7 +55,7 @@ function pdfExport(data) {
   doc.save('roles.pdf');
 }
 
-export default function RoleList({ teamId, open, onClose }) {
+export default function RoleList({ teamId, teamName, open, onClose }) {
   const [roles, setRoles] = React.useState([]);
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [editing, setEditing] = React.useState(null);
@@ -121,7 +121,7 @@ export default function RoleList({ teamId, open, onClose }) {
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>Roles</DialogTitle>
+      <DialogTitle>{`Roles del equipo ${teamName}`}</DialogTitle>
       <DialogContent>
         <Tooltip title={view === 'table' ? 'Vista tarjetas' : 'Vista tabla'}>
           <IconButton onClick={() => setView(view === 'table' ? 'cards' : 'table')}>

--- a/client/src/components/TeamList.jsx
+++ b/client/src/components/TeamList.jsx
@@ -48,7 +48,7 @@ function csvExport(data) {
 
 function pdfExport(data) {
   const doc = new jsPDF();
-  doc.text('Equipos', 10, 10);
+  doc.text('Equipos y roles', 10, 10);
   let y = 20;
   data.forEach(t => {
     doc.text(`${t.order} - ${t.name}`, 10, y);
@@ -128,7 +128,7 @@ export default function TeamList({ modelId, open, onClose }) {
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>Equipos</DialogTitle>
+      <DialogTitle>Equipos y roles</DialogTitle>
       <DialogContent>
         <Tooltip title={view === 'table' ? 'Vista tarjetas' : 'Vista tabla'}>
           <IconButton onClick={() => setView(view === 'table' ? 'cards' : 'table')}>
@@ -242,7 +242,12 @@ export default function TeamList({ modelId, open, onClose }) {
           </DialogActions>
         </Dialog>
         {rolesTeam && (
-          <RoleList open={!!rolesTeam} teamId={rolesTeam.id} onClose={() => setRolesTeam(null)} />
+          <RoleList
+            open={!!rolesTeam}
+            teamId={rolesTeam.id}
+            teamName={rolesTeam.name}
+            onClose={() => setRolesTeam(null)}
+          />
         )}
       </DialogContent>
       <DialogActions>


### PR DESCRIPTION
## Summary
- rename team management dialog and menu to **Equipos y roles**
- include team name in role dialog title

## Testing
- `npm run build` *(fails: DocumentCategoryList.jsx parse errors)*
- `npm start` in server *(fails: database connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c8a2b22208331978229520c731551