### PR TITLE
Fix document categories dialog, spacing, and remove parameter delete

### DIFF
--- a/client/src/components/DocumentCategoryList.jsx
+++ b/client/src/components/DocumentCategoryList.jsx
@@ -120,9 +120,7 @@ export default function DocumentCategoryList() {
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>Categorías de documento</DialogTitle>
-      <DialogContent>
+    <div>
         <Tooltip title={view === 'table' ? 'Vista tarjetas' : 'Vista tabla'}>
           <IconButton onClick={() => setView(view === 'table' ? 'cards' : 'table')}>
             {view === 'table' ? <ViewModuleIcon /> : <TableRowsIcon />}
@@ -222,10 +220,6 @@ export default function DocumentCategoryList() {
             <Button onClick={handleSave}>Guardar</Button>
           </DialogActions>
         </Dialog>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={onClose}>Cerrar</Button>
-        </DialogActions>
-      </Dialog>
+    </div>
   );
 }

--- a/client/src/components/ModelList.jsx
+++ b/client/src/components/ModelList.jsx
@@ -292,7 +292,7 @@ export default function ModelList({ readOnly = false, initialView = 'table' }) {
         <DialogTitle>{editing ? 'Editar' : 'Nuevo'} modelo</DialogTitle>
         <DialogContent>
           <TextField required label="Nombre" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} fullWidth />
-          <TextField required label="Autor" value={form.author} onChange={(e) => setForm({ ...form, author: e.target.value })} fullWidth />
+          <TextField required label="Autor" value={form.author} onChange={(e) => setForm({ ...form, author: e.target.value })} fullWidth sx={{ mt: 2 }} />
           <FormControl fullWidth sx={{ mt: 2 }}>
             <InputLabel>Modelo padre</InputLabel>
             <Select

--- a/client/src/components/ParameterList.jsx
+++ b/client/src/components/ParameterList.jsx
@@ -26,7 +26,6 @@ import TableRowsIcon from '@mui/icons-material/TableRows';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import RestoreIcon from '@mui/icons-material/Restore';
 import { jsPDF } from 'jspdf';
@@ -185,11 +184,6 @@ export default function ParameterList() {
                         <RestoreIcon />
                       </IconButton>
                     </Tooltip>
-                    <Tooltip title="Eliminar">
-                      <IconButton color="error" onClick={() => handleDelete(param.id)}>
-                        <DeleteIcon />
-                      </IconButton>
-                    </Tooltip>
 
                   </TableCell>
                 </TableRow>
@@ -214,11 +208,6 @@ export default function ParameterList() {
                   <Tooltip title="Reset">
                     <IconButton color="secondary" onClick={() => handleReset(param.id)}>
                       <RestoreIcon />
-                    </IconButton>
-                  </Tooltip>
-                  <Tooltip title="Eliminar">
-                    <IconButton color="error" onClick={() => handleDelete(param.id)}>
-                      <DeleteIcon />
                     </IconButton>
                   </Tooltip>
 


### PR DESCRIPTION
## Summary
- remove outer dialog from DocumentCategoryList so it renders correctly
- add margin to model edit dialog fields
- remove delete option from parameters list

## Testing
- `npm test --silent -- -u` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_684c8df023ec833196f5f76f094b162b