### PR TITLE
Remove submenu for admin page

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -3,35 +3,20 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
-import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import SettingsIcon from '@mui/icons-material/Settings';
 
 export default function Header({ appName, onAdmin, onModels }) {
-  const [anchorEl, setAnchorEl] = React.useState(null);
-
-  const handleSettingsClick = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
   return (
     <AppBar position="static">
       <Toolbar>
         <Typography variant="h6" sx={{ flexGrow: 1 }}>
           {appName}
         </Typography>
-        <MenuItem onClick={() => { handleClose(); onModels(); }}>Modelos</MenuItem>
-        <IconButton color="inherit" onClick={handleSettingsClick}>
+        <MenuItem onClick={onModels}>Modelos</MenuItem>
+        <IconButton color="inherit" onClick={onAdmin}>
           <SettingsIcon />
         </IconButton>
-        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-          <MenuItem onClick={() => { handleClose(); onAdmin(); }}>Gestión</MenuItem>
-
-        </Menu>
       </Toolbar>
     </AppBar>
   );


### PR DESCRIPTION
## Summary
- show admin page directly when clicking the gear icon

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c8e315cb4833181f77bb87b29e6bb