### PR TITLE
Enable node editing from models page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -30,7 +30,7 @@ function App() {
               onModels={() => { closeAll(); setShowPublicModels(true); }}
               onAdmin={() => { closeAll(); setShowAdmin(true); }} />
       <Container sx={{ mt: 2 }}>
-        {showPublicModels && <ModelList readOnly initialView="cards" />}
+        {showPublicModels && <ModelList readOnly initialView="cards" enableNodeEdit />}
         {showAdmin && <AdminPage />}
 
       </Container>

--- a/client/src/components/AdminPage.jsx
+++ b/client/src/components/AdminPage.jsx
@@ -15,7 +15,7 @@ export default function AdminPage() {
         <Tab label="Categorías" />
         <Tab label="Parámetros" />
       </Tabs>
-      {tab === 0 && <ModelList />}
+      {tab === 0 && <ModelList enableNodeEdit={false} />}
       {tab === 1 && <DocumentCategoryList />}
       {tab === 2 && <ParameterList />}
     </Box>

--- a/client/src/components/ModelList.jsx
+++ b/client/src/components/ModelList.jsx
@@ -76,7 +76,7 @@ function getBreadcrumb(model, models) {
   return names.join(' > ');
 }
 
-export default function ModelList({ readOnly = false, initialView = 'table' }) {
+export default function ModelList({ readOnly = false, initialView = 'table', enableNodeEdit = false }) {
   const [models, setModels] = React.useState([]);
   const [open, setOpen] = React.useState(false);
   const [editing, setEditing] = React.useState(null);
@@ -228,11 +228,13 @@ export default function ModelList({ readOnly = false, initialView = 'table' }) {
                           <GroupsIcon />
                         </IconButton>
                       </Tooltip>
-                      <Tooltip title="Nodos">
-                        <IconButton onClick={() => openNodes(model)}>
-                          <AccountTreeIcon />
-                        </IconButton>
-                      </Tooltip>
+                      {enableNodeEdit && (
+                        <Tooltip title="Nodos">
+                          <IconButton onClick={() => openNodes(model)}>
+                            <AccountTreeIcon />
+                          </IconButton>
+                        </Tooltip>
+                      )}
                       <Tooltip title="Eliminar">
                         <IconButton color="error" onClick={() => handleDelete(model.id)}>
                           <DeleteIcon />
@@ -270,11 +272,13 @@ export default function ModelList({ readOnly = false, initialView = 'table' }) {
                           <GroupsIcon />
                         </IconButton>
                       </Tooltip>
-                      <Tooltip title="Nodos">
-                        <IconButton onClick={() => openNodes(model)}>
-                          <AccountTreeIcon />
-                        </IconButton>
-                      </Tooltip>
+                      {enableNodeEdit && (
+                        <Tooltip title="Nodos">
+                          <IconButton onClick={() => openNodes(model)}>
+                            <AccountTreeIcon />
+                          </IconButton>
+                        </Tooltip>
+                      )}
                       <Tooltip title="Eliminar">
                         <IconButton color="error" onClick={() => handleDelete(model.id)}>
                           <DeleteIcon />
@@ -318,7 +322,7 @@ export default function ModelList({ readOnly = false, initialView = 'table' }) {
       {teamsModel && (
         <TeamList open={!!teamsModel} modelId={teamsModel.id} onClose={() => setTeamsModel(null)} />
       )}
-      {nodesModel && (
+      {enableNodeEdit && nodesModel && (
         <NodeList open={!!nodesModel} modelId={nodesModel.id} onClose={() => setNodesModel(null)} />
       )}
     </div>

--- a/client/src/components/NodeList.jsx
+++ b/client/src/components/NodeList.jsx
@@ -249,8 +249,7 @@ export default function NodeList({ modelId, open, onClose }) {
         </div>
         )}
         <TreeView
-          defaultCollapseIcon={<ExpandMoreIcon />}
-          defaultExpandIcon={<ChevronRightIcon />}
+          slots={{ collapseIcon: ExpandMoreIcon, expandIcon: ChevronRightIcon }}
         >
           {renderTree(null)}
         </TreeView>


### PR DESCRIPTION
## Summary
- update ModelList to optionally allow node editing separately from other admin actions
- move node editing access to the main public models view
- remove node editing access from admin page
- fix TreeView icon props for NodeList

## Testing
- `npm test --silent` (no output)
- `npm test --silent` in `server` (no output)
- `npm test --silent` in `client` (no output)

------
https://chatgpt.com/codex/tasks/task_e_684c9003645c8331b2e95c5c3d5a2aaf