### PR TITLE
Prevent self-parent models

### DIFF
--- a/client/src/components/ModelList.jsx
+++ b/client/src/components/ModelList.jsx
@@ -97,6 +97,10 @@ export default function ModelList({ readOnly = false, initialView = 'table', ena
   React.useEffect(() => { load(); }, []);
 
   const handleSave = async () => {
+    if (editing && parseInt(form.parentId) === editing.id) {
+      alert('Un modelo no puede ser su propio padre');
+      return;
+    }
     if (editing) {
       await axios.put(`/api/models/${editing.id}`, { ...form, parentId: form.parentId || null });
     } else {

--- a/server/index.js
+++ b/server/index.js
@@ -208,6 +208,9 @@ app.post('/api/models', async (req, res) => {
 });
 
 app.put('/api/models/:id', async (req, res) => {
+  if (req.body.parentId && parseInt(req.body.parentId) === parseInt(req.params.id)) {
+    return res.status(400).json({ error: 'Un modelo no puede ser su propio padre' });
+  }
   await Model.update(req.body, { where: { id: req.params.id } });
   const model = await Model.findByPk(req.params.id);
   res.json(model);


### PR DESCRIPTION
## Summary
- add client-side check preventing a model from selecting itself as parent
- enforce the rule on the server when updating models

## Testing
- `npm test` *(fails: Missing script)*
- `node index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684c925932f083319d75a06cea88578d