### PR TITLE
Link document categories to model

### DIFF
--- a/client/src/components/AdminPage.jsx
+++ b/client/src/components/AdminPage.jsx
@@ -3,7 +3,6 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
 import ModelList from './ModelList';
-import DocumentCategoryList from './DocumentCategoryList';
 import ParameterList from './ParameterList';
 
 export default function AdminPage() {
@@ -12,12 +11,10 @@ export default function AdminPage() {
     <Box>
       <Tabs value={tab} onChange={(e, v) => setTab(v)} sx={{ mb: 2 }}>
         <Tab label="Modelos" />
-        <Tab label="Categoría de documentos" />
         <Tab label="Parámetros" />
       </Tabs>
       {tab === 0 && <ModelList enableNodeEdit={false} />}
-      {tab === 1 && <DocumentCategoryList />}
-      {tab === 2 && <ParameterList />}
+      {tab === 1 && <ParameterList />}
     </Box>
   );
 }

--- a/client/src/components/DocumentCategoryList.jsx
+++ b/client/src/components/DocumentCategoryList.jsx
@@ -55,7 +55,7 @@ function pdfExport(data) {
   doc.save('categorias_documentos.pdf');
 }
 
-export default function DocumentCategoryList() {
+export default function DocumentCategoryList({ modelId, open, onClose }) {
   const [cats, setCats] = React.useState([]);
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [editing, setEditing] = React.useState(null);
@@ -66,17 +66,17 @@ export default function DocumentCategoryList() {
   const [sort, setSort] = React.useState({ key: 'name', dir: 'asc' });
 
   const load = async () => {
-    const res = await axios.get('/api/categoria-documentos');
+    const res = await axios.get(`/api/models/${modelId}/categoria-documentos`);
     setCats(res.data);
   };
 
-  React.useEffect(() => { load(); }, []);
+  React.useEffect(() => { if (open) load(); }, [open]);
 
   const handleSave = async () => {
     if (editing) {
       await axios.put(`/api/categoria-documentos/${editing.id}`, form);
     } else {
-      await axios.post('/api/categoria-documentos', form);
+      await axios.post(`/api/models/${modelId}/categoria-documentos`, form);
     }
     setDialogOpen(false);
     setForm({ name: '' });
@@ -120,7 +120,9 @@ export default function DocumentCategoryList() {
   };
 
   return (
-    <div>
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>Categorías de documentos</DialogTitle>
+      <DialogContent>
         <Tooltip title={view === 'table' ? 'Vista tarjetas' : 'Vista tabla'}>
           <IconButton onClick={() => setView(view === 'table' ? 'cards' : 'table')}>
             {view === 'table' ? <ViewModuleIcon /> : <TableRowsIcon />}
@@ -220,6 +222,10 @@ export default function DocumentCategoryList() {
             <Button onClick={handleSave}>Guardar</Button>
           </DialogActions>
         </Dialog>
-    </div>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cerrar</Button>
+      </DialogActions>
+    </Dialog>
   );
 }

--- a/client/src/components/ModelList.jsx
+++ b/client/src/components/ModelList.jsx
@@ -35,10 +35,12 @@ import LabelIcon from '@mui/icons-material/Label';
 import GroupsIcon from '@mui/icons-material/Groups';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import DescriptionIcon from '@mui/icons-material/Description';
 import { jsPDF } from 'jspdf';
 import TagList from './TagList';
 import TeamList from './TeamList';
 import NodeList from './NodeList';
+import DocumentCategoryList from './DocumentCategoryList';
 
 function csvExport(data) {
   const header = 'Nombre;Autor';
@@ -88,6 +90,7 @@ export default function ModelList({ readOnly = false, initialView = 'table', ena
   const [tagsModel, setTagsModel] = React.useState(null);
   const [teamsModel, setTeamsModel] = React.useState(null);
   const [nodesModel, setNodesModel] = React.useState(null);
+  const [categoriesModel, setCategoriesModel] = React.useState(null);
 
   const load = async () => {
     const res = await axios.get('/api/models');
@@ -133,6 +136,10 @@ export default function ModelList({ readOnly = false, initialView = 'table', ena
 
   const openTags = (model) => {
     setTagsModel(model);
+  };
+
+  const openCategories = (model) => {
+    setCategoriesModel(model);
   };
 
   const openTeams = (model) => {
@@ -231,6 +238,11 @@ export default function ModelList({ readOnly = false, initialView = 'table', ena
                               <LabelIcon />
                             </IconButton>
                           </Tooltip>
+                          <Tooltip title="Categorías de documentos">
+                            <IconButton onClick={() => openCategories(model)}>
+                              <DescriptionIcon />
+                            </IconButton>
+                          </Tooltip>
                           <Tooltip title="Equipos y roles">
                             <IconButton onClick={() => openTeams(model)}>
                               <GroupsIcon />
@@ -279,6 +291,11 @@ export default function ModelList({ readOnly = false, initialView = 'table', ena
                           <Tooltip title="Tags">
                             <IconButton onClick={() => openTags(model)}>
                               <LabelIcon />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title="Categorías de documentos">
+                            <IconButton onClick={() => openCategories(model)}>
+                              <DescriptionIcon />
                             </IconButton>
                           </Tooltip>
                           <Tooltip title="Equipos y roles">
@@ -336,6 +353,9 @@ export default function ModelList({ readOnly = false, initialView = 'table', ena
       </Dialog>
       {tagsModel && (
         <TagList open={!!tagsModel} modelId={tagsModel.id} onClose={() => setTagsModel(null)} />
+      )}
+      {categoriesModel && (
+        <DocumentCategoryList open={!!categoriesModel} modelId={categoriesModel.id} onClose={() => setCategoriesModel(null)} />
       )}
       {teamsModel && (
         <TeamList open={!!teamsModel} modelId={teamsModel.id} onClose={() => setTeamsModel(null)} />

--- a/client/src/components/NodeList.jsx
+++ b/client/src/components/NodeList.jsx
@@ -90,7 +90,7 @@ export default function NodeList({ modelId, open, onClose }) {
   };
 
   const loadCategories = async () => {
-    const res = await axios.get('/api/categoria-documentos');
+    const res = await axios.get(`/api/models/${modelId}/categoria-documentos`);
     setCategories(res.data);
   };
 


### PR DESCRIPTION
## Summary
- connect document categories to a specific model
- open document category manager from Model list
- load categories scoped by model when editing nodes
- validate node attachment category belongs to node's model
- drop obsolete admin tab

## Testing
- `npm install` and `npm run build` in `client`
- `npm install` and `timeout 5 node index.js` in `server` *(fails: Database connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c9550120c833187e4bdf500351813