### PR TITLE
Fix category creation error

### DIFF
--- a/client/src/components/DocumentCategoryList.jsx
+++ b/client/src/components/DocumentCategoryList.jsx
@@ -73,6 +73,10 @@ export default function DocumentCategoryList({ modelId, open, onClose }) {
   React.useEffect(() => { if (open) load(); }, [open]);
 
   const handleSave = async () => {
+    if (!form.name.trim()) {
+      alert('El nombre es obligatorio');
+      return;
+    }
     if (editing) {
       await axios.put(`/api/categoria-documentos/${editing.id}`, form);
     } else {

--- a/server/index.js
+++ b/server/index.js
@@ -292,14 +292,30 @@ app.get('/api/models/:modelId/categoria-documentos', async (req, res) => {
 });
 
 app.post('/api/models/:modelId/categoria-documentos', async (req, res) => {
-  const cat = await CategoriaDocumento.create({ ...req.body, modelId: req.params.modelId });
-  res.json(cat);
+  try {
+    const model = await Model.findByPk(req.params.modelId);
+    if (!model) return res.status(404).json({ error: 'Modelo no encontrado' });
+    const cat = await CategoriaDocumento.create({
+      ...req.body,
+      modelId: model.id
+    });
+    res.json(cat);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error al crear categoría' });
+  }
 });
 
 app.put('/api/categoria-documentos/:id', async (req, res) => {
-  await CategoriaDocumento.update(req.body, { where: { id: req.params.id } });
-  const cat = await CategoriaDocumento.findByPk(req.params.id);
-  res.json(cat);
+  try {
+    const cat = await CategoriaDocumento.findByPk(req.params.id);
+    if (!cat) return res.status(404).json({ error: 'Categoría no encontrada' });
+    await cat.update(req.body);
+    res.json(cat);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error al actualizar categoría' });
+  }
 });
 
 app.delete('/api/categoria-documentos/:id', async (req, res) => {


### PR DESCRIPTION
## Summary
- handle missing models when creating document categories
- show validation error when name is blank

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c9da6ea388331aaedececb17b730d