### PR TITLE
Fix category save error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -246,7 +246,7 @@ async function initDatabase(retries = 5, delayMs = 2000) {
   for (let attempt = 1; ; attempt++) {
     try {
       await sequelize.authenticate();
-      await sequelize.sync();
+      await sequelize.sync({ alter: true });
       await Parameter.findOrCreate({
         where: { name: 'Nombre de la aplicación' },
         defaults: { value: 'MCM', defaultValue: 'MCM' }


### PR DESCRIPTION
## Summary
- update Sequelize sync call to alter existing tables when starting server

## Testing
- `npm test --silent` *(client)*
- `npm test --silent` *(server)*

------
https://chatgpt.com/codex/tasks/task_e_684c9fe569048331a78ddd88e7f66bd5