### PR TITLE
Fix DB port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Esta guía explica cómo poner en marcha la aplicación desde cero en un servido
    DB_USER=mcm
    DB_PASSWORD=clave_segura
    DB_HOST=localhost
+   DB_PORT=3309
    ENV
    cd ..
    ```

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ const sequelize = new Sequelize(
   process.env.DB_PASSWORD || '',
   {
   host: process.env.DB_HOST || 'localhost',
+  port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 3306,
   dialect: 'mariadb'
 });
 


### PR DESCRIPTION
## Summary
- allow setting the MariaDB port through `DB_PORT`
- document the new setting in the setup instructions

## Testing
- `npm test` in `server` *(fails: Missing script)*
- `npm test` in `client` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ca06bbc5c8331862a4a278e7decd6