### PR TITLE
Fix node list header overlay issue

### DIFF
--- a/client/src/components/NodeList.jsx
+++ b/client/src/components/NodeList.jsx
@@ -363,7 +363,7 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
   if (!open) return null;
 
   return (
-    <div style={{ position: 'fixed', top: 0, left: 0, width: '100%', height: '100%', backgroundColor: '#fff', overflow: 'auto', zIndex: 1300 }}>
+    <div style={{ position: 'fixed', top: '64px', left: 0, width: '100%', height: 'calc(100% - 64px)', backgroundColor: '#fff', overflow: 'auto', zIndex: 1300 }}>
       <div style={{ display: 'flex', alignItems: 'center', padding: '1rem', borderBottom: '1px solid #ccc' }}>
         <Button startIcon={<ArrowBackIcon />} onClick={onClose}>Volver a modelos</Button>
         <h2 style={{ marginLeft: '1rem' }}>Nodos del modelo {modelName}</h2>


### PR DESCRIPTION
## Summary
- keep application header visible when displaying the node list

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684cafb12e748331bcfc9b4a5683c03c