### PR TITLE
Fix sibling order recalculation

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -246,13 +246,15 @@ async function updateNodeAndDescendants(node) {
 async function recalculateSiblingOrders(parentId) {
   const siblings = await Node.findAll({
     where: { parentId },
-    order: [['order', 'ASC']]
+    order: [['order', 'ASC'], ['id', 'ASC']]
   });
   let current = 1;
   for (const sib of siblings) {
+    sib.order = current++;
     if (sib.codePattern === 'ORDER') {
-      sib.order = current++;
       await updateNodeAndDescendants(sib);
+    } else {
+      await sib.save();
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix function to keep order values for all sibling nodes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm --prefix client test` *(fails: Missing script: "test")*
- `npm --prefix server test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684cb1015f64833197f7a93d85876d00