### PR TITLE
Fix NodeAttachment schema for file uploads

### DIFF
--- a/server/models/NodeAttachment.js
+++ b/server/models/NodeAttachment.js
@@ -8,5 +8,15 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
     },
+    categoryId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
+    },
+    nodeId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
+    },
   });
 };


### PR DESCRIPTION
## Summary
- include `categoryId` and `nodeId` fields in the `NodeAttachment` model so uploading attachments works

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684da9fcd68883318cca7f89167e480f