### PR TITLE
Fix global undefined issue in client build

### DIFF
--- a/client/vite.config.mjs
+++ b/client/vite.config.mjs
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    global: 'globalThis'
+  },
   server: {
     host: true,
     proxy: {


### PR DESCRIPTION
## Summary
- fix Vite config so Draft.js can find the global variable

## Testing
- `npm test --prefix client` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684dacb2ac208331ad03f7e953bfe2c9