### PR TITLE
Fix NodeAttachment table name

### DIFF
--- a/server/models/NodeAttachment.js
+++ b/server/models/NodeAttachment.js
@@ -18,5 +18,5 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       defaultValue: 1,
     },
-  });
+  }, { tableName: 'node_attachments' });
 };


### PR DESCRIPTION
## Summary
- fix NodeAttachment table name to match database

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dae2d513c83319a70201c51e5c38d