### PR TITLE
Fix default parameter editing

### DIFF
--- a/client/src/components/parameters/ParameterList.jsx
+++ b/client/src/components/parameters/ParameterList.jsx
@@ -75,7 +75,10 @@ export default function ParameterList() {
 
   const [save, saving] = useProcessingAction(async () => {
     if (editing) {
-      await axios.put(`/api/parameters/${editing.id}`, form);
+      await axios.put(`/api/parameters/${editing.id}`, {
+        name: form.name,
+        value: form.value,
+      });
     } else {
       await axios.post('/api/parameters', form);
     }
@@ -220,9 +223,28 @@ export default function ParameterList() {
       <Dialog open={open} onClose={() => setOpen(false)}>
         <DialogTitle>{editing ? 'Editar' : 'Nuevo'} parámetro</DialogTitle>
         <DialogContent>
-          <TextField required label="Nombre" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} fullWidth />
-          <TextField required label="Valor" value={form.value} onChange={(e) => setForm({ ...form, value: e.target.value })} fullWidth />
-          <TextField required label="Valor por defecto" value={form.defaultValue} onChange={(e) => setForm({ ...form, defaultValue: e.target.value })} fullWidth />
+          <TextField
+            required
+            label="Nombre"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            fullWidth
+          />
+          <TextField
+            required
+            label="Valor"
+            value={form.value}
+            onChange={(e) => setForm({ ...form, value: e.target.value })}
+            fullWidth
+          />
+          <TextField
+            required
+            label="Valor por defecto"
+            value={form.defaultValue}
+            onChange={(e) => setForm({ ...form, defaultValue: e.target.value })}
+            fullWidth
+            disabled={Boolean(editing)}
+          />
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setOpen(false)} disabled={saving}>Cancelar</Button>

--- a/server/routes/parameters.js
+++ b/server/routes/parameters.js
@@ -19,7 +19,8 @@ router.post('/', async (req, res) => {
 });
 
 router.put('/:id', async (req, res) => {
-  await Parameter.update(req.body, { where: { id: req.params.id } });
+  const { name, value } = req.body;
+  await Parameter.update({ name, value }, { where: { id: req.params.id } });
   const param = await Parameter.findByPk(req.params.id);
   res.json(param);
 });


### PR DESCRIPTION
## Summary
- disable editing of parameter default value in UI
- prevent updates to `defaultValue` server-side

## Testing
- `npm run build` in `client`
- `npm install` in `server`
- `npm start` in `server` *(fails: unable to connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_684db0dd147483319da0228d6d849ad3