### PR TITLE
Add node detail actions with PDF export

### DIFF
--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -1,12 +1,43 @@
 import React from 'react';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 
-export default function NodeDetails({ node, attachments }) {
+export default function NodeDetails({ node, attachments, onEdit, onDelete, onExport }) {
   if (!node) {
     return <div>Selecciona un nodo</div>;
   }
 
+  const contentRef = React.useRef(null);
+
   return (
     <div>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '0.5rem' }}>
+        <Tooltip title="Editar nodo">
+          <span>
+            <IconButton size="small" onClick={onEdit} disabled={!onEdit}>
+              <EditIcon fontSize="inherit" />
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title="Eliminar nodo">
+          <span>
+            <IconButton size="small" color="error" onClick={onDelete} disabled={!onDelete} sx={{ ml: 0.5 }}>
+              <DeleteIcon fontSize="inherit" />
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title="Exportar PDF">
+          <span>
+            <IconButton size="small" onClick={() => onExport && onExport(contentRef.current)} sx={{ ml: 0.5 }}>
+              <PictureAsPdfIcon fontSize="inherit" />
+            </IconButton>
+          </span>
+        </Tooltip>
+      </div>
+      <div ref={contentRef} id="node-details-content">
       <h2>[{node.code}] {node.name}</h2>
       {node.tags && node.tags.length > 0 && (
         <div style={{ marginBottom: '1rem' }}>
@@ -63,6 +94,7 @@ export default function NodeDetails({ node, attachments }) {
           </ul>
         </div>
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add action buttons to NodeDetails
- enable exporting node details as PDF using html2canvas and jsPDF
- wire NodeList to pass edit/delete/export handlers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e042fca6083318f16fbf5f9ec5a56