### PR TITLE
Fix RASCI role selection rules

### DIFF
--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -843,9 +843,18 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
                       value={rasciForm.teamId}
                       onChange={e => setRasciForm({ ...rasciForm, teamId: e.target.value, roleId: '' })}
                     >
-                      {teams.map(t => (
-                        <MenuItem key={t.id} value={t.id}>{t.name}</MenuItem>
-                      ))}
+                      {teams
+                        .filter(t => {
+                          const used = rasciLines
+                            .filter((_, idx) => idx !== editingRasciIdx)
+                            .map(l => l.roleId);
+                          const available = (roles[t.id] || []).some(r => !used.includes(r.id));
+                          if (editingRasciIdx !== null && rasciLines[editingRasciIdx].teamId === t.id) return true;
+                          return available;
+                        })
+                        .map(t => (
+                          <MenuItem key={t.id} value={t.id}>{t.name}</MenuItem>
+                        ))}
                     </Select>
                   </FormControl>
                   <FormControl fullWidth required sx={{ mt: 2 }}>
@@ -855,9 +864,17 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
                       value={rasciForm.roleId}
                       onChange={e => setRasciForm({ ...rasciForm, roleId: e.target.value })}
                     >
-                      {(roles[rasciForm.teamId] || []).map(r => (
-                        <MenuItem key={r.id} value={r.id}>{r.name}</MenuItem>
-                      ))}
+                      {(roles[rasciForm.teamId] || [])
+                        .filter(r => {
+                          const used = rasciLines
+                            .filter((_, idx) => idx !== editingRasciIdx)
+                            .map(l => l.roleId);
+                          if (editingRasciIdx !== null && rasciLines[editingRasciIdx].roleId === r.id) return true;
+                          return !used.includes(r.id);
+                        })
+                        .map(r => (
+                          <MenuItem key={r.id} value={r.id}>{r.name}</MenuItem>
+                        ))}
                     </Select>
                   </FormControl>
                   <div style={{ display: 'flex', marginTop: '1rem' }}>

--- a/server/routes/nodes.js
+++ b/server/routes/nodes.js
@@ -18,9 +18,14 @@ function validateRasciLines(rasci) {
   if (!rasci || !rasci.length) return;
   let countA = 0;
   let countR = 0;
+  const usedRoles = new Set();
   for (const line of rasci) {
     if (line.responsibilities.includes('A')) countA++;
     if (line.responsibilities.includes('R')) countR++;
+    if (usedRoles.has(line.roleId)) {
+      throw new Error('Un rol sólo puede aparecer una vez en el RASCI del nodo');
+    }
+    usedRoles.add(line.roleId);
   }
   if (countA === 0 || countR === 0) {
     throw new Error('Debe existir al menos un rol con responsabilidad A y otro con responsabilidad R');


### PR DESCRIPTION
## Summary
- enforce unique role per node on the backend
- hide already used roles in RASCI popup
- disable teams with all roles already selected

## Testing
- `npm test --prefix client` *(fails: Missing script)*
- `npm test --prefix server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e04862e648331aaf318a882e94d56