### PR TITLE
Add node actions and pdf export in details

### DIFF
--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -1,13 +1,54 @@
 import React from 'react';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import { jsPDF } from 'jspdf';
 
-export default function NodeDetails({ node, attachments }) {
+export default function NodeDetails({ node, attachments, onEdit, onDelete }) {
   if (!node) {
     return <div>Selecciona un nodo</div>;
   }
 
+  const contentRef = React.useRef(null);
+
+  const exportPdf = () => {
+    if (!contentRef.current) return;
+    const doc = new jsPDF('p', 'pt', 'a4');
+    doc.html(contentRef.current, {
+      callback: () => doc.save(`${node.code}.pdf`),
+      html2canvas: { scale: 0.8 }
+    });
+  };
+
   return (
     <div>
-      <h2>[{node.code}] {node.name}</h2>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h2 style={{ margin: 0 }}>[{node.code}] {node.name}</h2>
+        <div>
+          {onEdit && (
+            <Tooltip title="Editar nodo">
+              <IconButton size="small" onClick={() => onEdit(node)}>
+                <EditIcon fontSize="inherit" />
+              </IconButton>
+            </Tooltip>
+          )}
+          {onDelete && (
+            <Tooltip title="Borrar nodo">
+              <IconButton size="small" color="error" onClick={() => onDelete(node.id)}>
+                <DeleteIcon fontSize="inherit" />
+              </IconButton>
+            </Tooltip>
+          )}
+          <Tooltip title="Exportar PDF">
+            <IconButton size="small" onClick={exportPdf} sx={{ ml: 0.5 }}>
+              <PictureAsPdfIcon fontSize="inherit" />
+            </IconButton>
+          </Tooltip>
+        </div>
+      </div>
+      <div ref={contentRef}>
       {node.tags && node.tags.length > 0 && (
         <div style={{ marginBottom: '1rem' }}>
           {node.tags.map(tag => (
@@ -63,6 +104,7 @@ export default function NodeDetails({ node, attachments }) {
           </ul>
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -667,7 +667,12 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
             <IconButton size="small" onClick={() => setDetailsOpen(false)} style={{ position: 'absolute', top: 0, right: 0 }}>
               <ChevronRightIcon />
             </IconButton>
-            <NodeDetails node={viewNode} attachments={viewAttachments} />
+            <NodeDetails
+              node={viewNode}
+              attachments={viewAttachments}
+              onEdit={openEdit}
+              onDelete={handleDelete}
+            />
           </div>
         ) : (
           <div style={{ position: 'absolute', top: 0, right: 0 }}>


### PR DESCRIPTION
## Summary
- add edit/delete/pdf icons to selected node details
- hook node list to support edit/delete from details panel

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e05a2061883318cda3d80d03db953