### PR TITLE
Enhance tag filtering in node details

### DIFF
--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -9,7 +9,7 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 
-export default function NodeDetails({ node, attachments, onEdit, onDelete }) {
+export default function NodeDetails({ node, attachments, onEdit, onDelete, onTagClick }) {
   if (!node) {
     return <div>Selecciona un nodo</div>;
   }
@@ -72,12 +72,14 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete }) {
           {node.tags.map(tag => (
             <span
               key={tag.id}
+              onClick={onTagClick ? () => onTagClick(tag.id) : undefined}
               style={{
                 backgroundColor: tag.bgColor,
                 color: tag.textColor,
                 padding: '0 0.25rem',
                 marginRight: '0.25rem',
-                borderRadius: '4px'
+                borderRadius: '4px',
+                cursor: onTagClick ? 'pointer' : 'default'
               }}
             >
               {tag.name}

--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -672,6 +672,7 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
               attachments={viewAttachments}
               onEdit={openEdit}
               onDelete={handleDelete}
+              onTagClick={(id) => { setShowFilters(true); setFilterTags([id]); }}
             />
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- make tags clickable in `NodeDetails`
- trigger filters in `NodeList` when clicking a tag in the details view

## Testing
- `npm test --silent` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_684e06d0262083318bb8c9d720f2fc6d