### PR TITLE
Fix attachment download paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 client/node_modules
 server/node_modules
 .env
+client/dist

--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -124,7 +124,7 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete }) {
           <ul>
             {attachments.map(att => (
               <li key={att.id}>
-                <a href={`/${att.filePath}`} download>{att.name}</a>{' '}
+                <a href={`/api/attachments/${att.id}/download`}>{att.name}</a>{' '}
                 (<span>{att.CategoriaDocumento.name}</span>)
               </li>
             ))}

--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -969,7 +969,7 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
                         <TableRow key={att.id}>
                           <TableCell>{att.CategoriaDocumento.name}</TableCell>
                           <TableCell>
-                            <a href={`/${att.filePath}`} download>{att.name}</a>
+                            <a href={`/api/attachments/${att.id}/download`}>{att.name}</a>
                           </TableCell>
                           <TableCell>
                             <Tooltip title="Eliminar archivo">

--- a/server/routes/nodes.js
+++ b/server/routes/nodes.js
@@ -199,6 +199,13 @@ router.post('/:nodeId/attachments', upload.single('file'), async (req, res) => {
   res.json(full);
 });
 
+router.get('/attachments/:id/download', async (req, res) => {
+  const att = await NodeAttachment.findByPk(req.params.id);
+  if (!att) return res.status(404).end();
+  const file = path.join(__dirname, '..', att.filePath);
+  res.download(file, att.name);
+});
+
 router.delete('/attachments/:id', async (req, res) => {
   const att = await NodeAttachment.findByPk(req.params.id);
   if (att) {


### PR DESCRIPTION
## Summary
- download attachments securely from the server using a new API route
- update attachment links in Node views to use the download endpoint
- ignore generated `client/dist` directory

## Testing
- `npm run build` in `client`
- `npm install` in `server`


------
https://chatgpt.com/codex/tasks/task_e_684e073e10bc83319c8c207005cedcd0