### PR TITLE
Refresh node data after reordering

### DIFF
--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -362,13 +362,13 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
     } else {
       res = await axios.post(`/api/models/${modelId}/nodes`, payload);
     }
-    setFocusNodeId(res.data.id);
     setDialogOpen(false);
     setForm({ parentId: '', code: '', name: '', patternType: 'order', patternText: '', description: '' });
     setSelectedTags([]);
     setRasciLines([]);
     setEditing(null);
-    load();
+    await load();
+    setFocusNodeId(res.data.id);
   });
 
   const [removeNode, removing] = useProcessingAction(async (id) => {
@@ -384,8 +384,8 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
 
   const [moveNode, moving] = useProcessingAction(async (id, direction) => {
     await axios.post(`/api/nodes/${id}/move`, { direction });
+    await load();
     setFocusNodeId(id);
-    load();
   });
 
   const openEdit = async (node) => {


### PR DESCRIPTION
## Summary
- make node detail view refresh after changing order

## Testing
- `npm run build` *(fails: vite not found, so ran `npm install` first)*

------
https://chatgpt.com/codex/tasks/task_e_684e07a4bad4833191f076f7e768b1b0