### PR TITLE
Fix node details layout and attachment links

### DIFF
--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -4,12 +4,13 @@ import Tooltip from '@mui/material/Tooltip';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { jsPDF } from 'jspdf';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 
-export default function NodeDetails({ node, attachments, onEdit, onDelete, onTagClick }) {
+export default function NodeDetails({ node, attachments, onEdit, onDelete, onTagClick, onClose }) {
   if (!node) {
     return <div>Selecciona un nodo</div>;
   }
@@ -42,9 +43,9 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '0.5rem' }}>
         <h2 style={{ margin: 0 }}>[{node.code}] {node.name}</h2>
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
           {onEdit && (
             <Tooltip title="Editar nodo">
               <IconButton size="small" onClick={() => onEdit(node)}>
@@ -64,6 +65,13 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
               <PictureAsPdfIcon fontSize="inherit" />
             </IconButton>
           </Tooltip>
+          {onClose && (
+            <Tooltip title="Ocultar detalles">
+              <IconButton size="small" onClick={onClose} sx={{ ml: 0.5 }}>
+                <ChevronRightIcon fontSize="inherit" />
+              </IconButton>
+            </Tooltip>
+          )}
         </div>
       </div>
       <div ref={contentRef}>
@@ -126,7 +134,7 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
           <ul>
             {attachments.map(att => (
               <li key={att.id}>
-                <a href={`/api/attachments/${att.id}/download`}>{att.name}</a>{' '}
+                <a href={`/api/nodes/attachments/${att.id}/download`}>{att.name}</a>{' '}
                 (<span>{att.CategoriaDocumento.name}</span>)
               </li>
             ))}

--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -139,7 +139,7 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
     loadAttachments(editing.id);
   });
   const [removeAttachment, removingAttachment] = useProcessingAction(async (id) => {
-    await axios.delete(`/api/attachments/${id}`);
+    await axios.delete(`/api/nodes/attachments/${id}`);
     loadAttachments(editing.id);
   });
   const [expanded, setExpanded] = React.useState([]);
@@ -663,16 +663,14 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
           </div>
         )}
         {detailsOpen ? (
-          <div style={{ width: `${100 - leftWidth}%`, padding: '1rem', overflowY: 'auto', position: 'relative' }}>
-            <IconButton size="small" onClick={() => setDetailsOpen(false)} style={{ position: 'absolute', top: 0, right: 0 }}>
-              <ChevronRightIcon />
-            </IconButton>
+          <div style={{ width: `${100 - leftWidth}%`, padding: '1rem', overflowY: 'auto' }}>
             <NodeDetails
               node={viewNode}
               attachments={viewAttachments}
               onEdit={openEdit}
               onDelete={handleDelete}
               onTagClick={(id) => { setShowFilters(true); setFilterTags([id]); }}
+              onClose={() => setDetailsOpen(false)}
             />
           </div>
         ) : (
@@ -970,7 +968,7 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
                         <TableRow key={att.id}>
                           <TableCell>{att.CategoriaDocumento.name}</TableCell>
                           <TableCell>
-                            <a href={`/api/attachments/${att.id}/download`}>{att.name}</a>
+                            <a href={`/api/nodes/attachments/${att.id}/download`}>{att.name}</a>
                           </TableCell>
                           <TableCell>
                             <Tooltip title="Eliminar archivo">


### PR DESCRIPTION
## Summary
- show collapse button inside NodeDetails header
- fix download/delete attachment routes
- update NodeList to use new onClose prop and correct links

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd server && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684e0a29acbc8331824976526db41a8d