### PR TITLE
Fix node sibling code recalculation on parent change

### DIFF
--- a/server/routes/nodes.js
+++ b/server/routes/nodes.js
@@ -92,9 +92,14 @@ router.put('/:id', async (req, res) => {
     if (conflict) return res.status(400).json({ error: 'Código duplicado' });
   }
   const previousPattern = node.codePattern;
+  const oldParentId = node.parentId;
   await node.update({ ...data, codePattern });
   await updateNodeAndDescendants(Node, node);
-  if (previousPattern === 'ORDER' && codePattern !== 'ORDER') {
+  const parentChanged = node.parentId !== oldParentId;
+  if (parentChanged) {
+    if (oldParentId) await recalculateSiblingOrders(Node, oldParentId);
+    await recalculateSiblingOrders(Node, node.parentId);
+  } else if (previousPattern === 'ORDER' && codePattern !== 'ORDER') {
     await recalculateSiblingOrders(Node, node.parentId);
   }
   const oldTagIds = node.tags.map(t => t.id);


### PR DESCRIPTION
## Summary
- ensure sibling orders are recalculated for both old and new parents when a node changes parent

## Testing
- `node --check server/routes/nodes.js`
- `node -e "require('./server/utils/nodeUtils');"`
- `node server/index.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684e0ad5f44c83318d550ecdfe445fb1