### PR TITLE
Add database import/export UI and routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,9 @@ Esta guía explica cómo poner en marcha la aplicación desde cero en un servido
    ```
 
 Con estos pasos la aplicación queda desplegada y lista para usarse.
+
+## Importación y exportación de datos
+
+Desde la sección de administración se puede descargar un volcado SQL de todos los registros pulsando en **Exportar**. El fichero generado contiene sentencias `INSERT` con actualización automática si el registro ya existe.
+
+Para importar, seleccione un fichero `.sql` y elija qué entidades cargar. Tras ejecutar la importación se mostrará un log con el resultado de cada sentencia.

--- a/client/src/components/AdminPage.jsx
+++ b/client/src/components/AdminPage.jsx
@@ -4,6 +4,7 @@ import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
 import ModelList from './models/ModelList';
 import ParameterList from './parameters/ParameterList';
+import DataTransfer from './data/DataTransfer';
 
 export default function AdminPage() {
   const [tab, setTab] = React.useState(0);
@@ -12,9 +13,11 @@ export default function AdminPage() {
       <Tabs value={tab} onChange={(e, v) => setTab(v)} sx={{ mb: 2 }}>
         <Tab label="Modelos" />
         <Tab label="Parámetros" />
+        <Tab label="Importación/Exportación" />
       </Tabs>
       {tab === 0 && <ModelList enableNodeEdit={false} />}
       {tab === 1 && <ParameterList />}
+      {tab === 2 && <DataTransfer />}
     </Box>
   );
 }

--- a/client/src/components/data/DataTransfer.jsx
+++ b/client/src/components/data/DataTransfer.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import axios from 'axios';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import TextField from '@mui/material/TextField';
+import useProcessingAction from '../../hooks/useProcessingAction';
+
+export default function DataTransfer() {
+  const [file, setFile] = React.useState(null);
+  const [entities, setEntities] = React.useState([]);
+  const [selected, setSelected] = React.useState([]);
+  const [log, setLog] = React.useState('');
+
+  const preview = async (f) => {
+    const form = new FormData();
+    form.append('file', f);
+    const res = await axios.post('/api/data/import/preview', form);
+    setEntities(res.data.entities);
+    setSelected(res.data.entities);
+  };
+
+  const handleFileChange = (e) => {
+    const f = e.target.files[0];
+    setFile(f);
+    if (f) preview(f);
+  };
+
+  const toggle = (name) => {
+    setSelected((prev) =>
+      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name]
+    );
+  };
+
+  const [runImport, running] = useProcessingAction(async () => {
+    if (!file) return;
+    const form = new FormData();
+    form.append('file', file);
+    form.append('entities', JSON.stringify(selected));
+    const res = await axios.post('/api/data/import', form);
+    setLog(res.data.log.join('\n'));
+  });
+
+  return (
+    <Box>
+      <Button variant="contained" onClick={() => { window.location = '/api/data/export'; }}>
+        Exportar
+      </Button>
+      <Box mt={2}>
+        <input type="file" accept=".sql" onChange={handleFileChange} />
+      </Box>
+      {entities.length > 0 && (
+        <Box mt={2}>
+          <Typography variant="h6">Entidades</Typography>
+          {entities.map((e) => (
+            <FormControlLabel
+              key={e}
+              control={
+                <Checkbox
+                  checked={selected.includes(e)}
+                  onChange={() => toggle(e)}
+                />
+              }
+              label={e}
+            />
+          ))}
+          <Box mt={1}>
+            <Button variant="contained" onClick={runImport} disabled={running}>
+              Ejecutar importación
+            </Button>
+          </Box>
+        </Box>
+      )}
+      {log && (
+        <TextField
+          label="Log"
+          multiline
+          fullWidth
+          value={log}
+          InputProps={{ readOnly: true }}
+          sx={{ mt: 2 }}
+        />
+      )}
+    </Box>
+  );
+}

--- a/server/app.js
+++ b/server/app.js
@@ -21,6 +21,7 @@ const teamRoutes = require('./routes/teams');
 const roleRoutes = require('./routes/roles');
 const categoriaRoutes = require('./routes/categoriaDocumentos');
 const nodeRoutes = require('./routes/nodes');
+const dataRoutes = require('./routes/data');
 
 app.use('/api/models', modelRoutes);
 app.use('/api/parameters', parameterRoutes);
@@ -30,5 +31,6 @@ app.use('/api/teams/:teamId/roles', roleRoutes);
 app.use('/api/models/:modelId/categoria-documentos', categoriaRoutes);
 app.use('/api/models/:modelId/nodes', nodeRoutes);
 app.use('/api/nodes', nodeRoutes);
+app.use('/api/data', dataRoutes);
 
 module.exports = { app, db };

--- a/server/routes/data.js
+++ b/server/routes/data.js
@@ -1,0 +1,80 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const multer = require('multer');
+const db = require('../models');
+
+const router = express.Router();
+const upload = multer({ dest: path.join(__dirname, '..', 'uploads', 'tmp') });
+
+const exportOrder = [
+  'Parameter',
+  'Model',
+  'Team',
+  'Role',
+  'CategoriaDocumento',
+  'Tag',
+  'Node',
+  'NodeTag',
+  'NodeAttachment',
+  'NodeRasci'
+];
+
+async function generateInsertSQL(model) {
+  const table = model.getTableName();
+  const rows = await model.findAll({ raw: true });
+  if (!rows.length) return '';
+  const cols = Object.keys(rows[0]);
+  const colList = cols.map(c => `\`${c}\``).join(',');
+  const updates = cols.map(c => `\`${c}\`=VALUES(\`${c}\`)`).join(',');
+  let sql = `-- Entity: ${model.name}\n`;
+  for (const row of rows) {
+    const vals = cols.map(c => model.sequelize.escape(row[c])).join(',');
+    sql += `INSERT INTO \`${table}\` (${colList}) VALUES (${vals}) ON DUPLICATE KEY UPDATE ${updates};\n`;
+  }
+  return sql + '\n';
+}
+
+router.get('/export', async (req, res) => {
+  let sql = '';
+  for (const name of exportOrder) {
+    const model = db[name];
+    if (model) sql += await generateInsertSQL(model);
+  }
+  res.header('Content-Type', 'text/plain');
+  res.attachment('export.sql');
+  res.send(sql);
+});
+
+router.post('/import/preview', upload.single('file'), (req, res) => {
+  const content = fs.readFileSync(req.file.path, 'utf-8');
+  fs.unlinkSync(req.file.path);
+  const entities = Array.from(new Set([...content.matchAll(/-- Entity: (\w+)/g)].map(m => m[1])));
+  res.json({ entities });
+});
+
+router.post('/import', upload.single('file'), async (req, res) => {
+  const selected = req.body.entities ? JSON.parse(req.body.entities) : [];
+  const content = fs.readFileSync(req.file.path, 'utf-8');
+  fs.unlinkSync(req.file.path);
+  const lines = content.split(/\r?\n/);
+  const statements = [];
+  let current = null;
+  for (const line of lines) {
+    const match = line.match(/^-- Entity: (\w+)/);
+    if (match) { current = match[1]; continue; }
+    if (current && selected.includes(current) && line.trim()) statements.push(line);
+  }
+  const log = [];
+  for (const stmt of statements) {
+    try {
+      await db.sequelize.query(stmt);
+      log.push('OK: ' + stmt);
+    } catch (err) {
+      log.push('ERROR: ' + stmt + ' -> ' + err.message);
+    }
+  }
+  res.json({ log });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add UI tab for DB import/export
- implement `DataTransfer` component with export and import logic
- expose API endpoints for export and import
- document how to use the feature

## Testing
- `npm install --silent` in `server`
- `npm install --silent` in `client`
- `npm run build` in `client`

------
https://chatgpt.com/codex/tasks/task_e_684e0bbe4eac8331a654fbafe1682f1c