### PR TITLE
Implement RASCI color mapping

### DIFF
--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -10,6 +10,14 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 
+const rasciStyles = {
+  R: { bg: '#ffcc80', border: '#ffa726' },
+  A: { bg: '#ef9a9a', border: '#e57373' },
+  S: { bg: '#fff59d', border: '#fff176' },
+  C: { bg: '#c8e6c9', border: '#a5d6a7' },
+  I: { bg: '#bbdefb', border: '#90caf9' }
+};
+
 export default function NodeDetails({ node, attachments, onEdit, onDelete, onTagClick, onClose }) {
   if (!node) {
     return <div>Selecciona un nodo</div>;
@@ -112,10 +120,10 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
                         style={{
                           marginRight: '0.25rem',
                           padding: '0.25rem 0.5rem',
-                          backgroundColor: line.responsibilities.includes(ch) ? '#c8e6c9' : 'transparent',
+                          backgroundColor: line.responsibilities.includes(ch) ? rasciStyles[ch].bg : 'transparent',
                           color: line.responsibilities.includes(ch) ? 'black' : '#ccc',
                           borderRadius: 4,
-                          border: line.responsibilities.includes(ch) ? '1px solid #a5d6a7' : '1px solid transparent'
+                          border: line.responsibilities.includes(ch) ? `1px solid ${rasciStyles[ch].border}` : '1px solid transparent'
                         }}
                       >
                         {ch}

--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -59,6 +59,14 @@ import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
 import NodeDetails from './NodeDetails';
 
+const rasciStyles = {
+  R: { bg: '#ffcc80', border: '#ffa726' },
+  A: { bg: '#ef9a9a', border: '#e57373' },
+  S: { bg: '#fff59d', border: '#fff176' },
+  C: { bg: '#c8e6c9', border: '#a5d6a7' },
+  I: { bg: '#bbdefb', border: '#90caf9' }
+};
+
 function csvExport(data) {
   const header = 'Código;Nombre;Nodo padre;Modelo';
   const rows = data.map(n => `${n.code};${n.name};${n.parentId || ''};${n.modelId}`);
@@ -903,10 +911,10 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
                             style={{
                               marginRight: '0.25rem',
                               padding: '0.25rem 0.5rem',
-                              backgroundColor: line.responsibilities.includes(ch) ? '#c8e6c9' : 'transparent',
+                              backgroundColor: line.responsibilities.includes(ch) ? rasciStyles[ch].bg : 'transparent',
                               color: line.responsibilities.includes(ch) ? 'black' : '#ccc',
                               borderRadius: 4,
-                              border: line.responsibilities.includes(ch) ? '1px solid #a5d6a7' : '1px solid transparent'
+                              border: line.responsibilities.includes(ch) ? `1px solid ${rasciStyles[ch].border}` : '1px solid transparent'
                             }}
                           >
                             {ch}


### PR DESCRIPTION
## Summary
- add rasciStyles constants to NodeDetails and NodeList
- color and border for RASCI letters use new mapping

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e0e7db2888331886f0dbea121a179