### PR TITLE
Fix node attachment downloads

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const cors = require('cors');
 const path = require('path');
+const fs = require('fs');
 const multer = require('multer');
 const db = require('./models');
 
@@ -10,8 +11,9 @@ app.use(cors());
 app.use(bodyParser.json());
 
 const uploadDir = path.join(__dirname, 'uploads');
-const upload = multer({ dest: uploadDir });
-app.use('/uploads', express.static(uploadDir));
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
 
 // Routers
 const modelRoutes = require('./routes/models');

--- a/server/routes/data.js
+++ b/server/routes/data.js
@@ -5,7 +5,11 @@ const multer = require('multer');
 const db = require('../models');
 
 const router = express.Router();
-const upload = multer({ dest: path.join(__dirname, '..', 'uploads', 'tmp') });
+const tmpUpload = path.join(__dirname, '..', 'uploads', 'tmp');
+if (!fs.existsSync(tmpUpload)) {
+  fs.mkdirSync(tmpUpload, { recursive: true });
+}
+const upload = multer({ dest: tmpUpload });
 
 const exportOrder = [
   'Parameter',

--- a/server/routes/nodes.js
+++ b/server/routes/nodes.js
@@ -12,7 +12,11 @@ const {
 } = require('../utils/nodeUtils');
 
 const router = express.Router({ mergeParams: true });
-const upload = multer({ dest: path.join(__dirname, '..', 'uploads') });
+const uploadPath = path.join(__dirname, '..', 'uploads');
+if (!fs.existsSync(uploadPath)) {
+  fs.mkdirSync(uploadPath, { recursive: true });
+}
+const upload = multer({ dest: uploadPath });
 
 function validateRasciLines(rasci) {
   if (!rasci || !rasci.length) return;
@@ -208,6 +212,7 @@ router.get('/attachments/:id/download', async (req, res) => {
   const att = await NodeAttachment.findByPk(req.params.id);
   if (!att) return res.status(404).end();
   const file = path.join(__dirname, '..', att.filePath);
+  if (!fs.existsSync(file)) return res.status(404).end();
   res.download(file, att.name);
 });
 


### PR DESCRIPTION
## Summary
- create `server/uploads` folder automatically and do not expose it directly
- ensure upload folders exist in data and node routes
- gracefully handle missing attachment files

## Testing
- `npm install` *(server)*
- `npm install` *(client)*
- `npm run build` *(client)*
- `node index.js` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684eb8d289048331b2d21d8076e4fc15