### PR TITLE
Enable filtering from node details

### DIFF
--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -18,7 +18,7 @@ const rasciStyles = {
   I: { bg: '#bbdefb', border: '#90caf9' }
 };
 
-export default function NodeDetails({ node, attachments, onEdit, onDelete, onTagClick, onClose }) {
+export default function NodeDetails({ node, attachments, onEdit, onDelete, onTagClick, onTeamClick, onRoleClick, onRespClick, onClose }) {
   if (!node) {
     return <div>Selecciona un nodo</div>;
   }
@@ -110,10 +110,21 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
           {rasciByTeam.map(group => (
             <Card key={group.team.id} sx={{ mt: 2 }}>
               <CardContent>
-                <Typography variant="h6">{group.team.order} - {group.team.name}</Typography>
+                <Typography
+                  variant="h6"
+                  sx={{ cursor: onTeamClick ? 'pointer' : 'default' }}
+                  onClick={onTeamClick ? () => onTeamClick(group.team.id) : undefined}
+                >
+                  {group.team.order} - {group.team.name}
+                </Typography>
                 {group.lines.map(line => (
                   <div key={line.id} style={{ display: 'flex', alignItems: 'center', marginTop: '0.5rem' }}>
-                    <span style={{ flex: 1 }}>{line.Role.name}</span>
+                    <span
+                      style={{ flex: 1, cursor: onRoleClick ? 'pointer' : 'default' }}
+                      onClick={onRoleClick ? () => onRoleClick(group.team.id, line.roleId) : undefined}
+                    >
+                      {line.Role.name}
+                    </span>
                     {['R','A','S','C','I'].map(ch => (
                       <span
                         key={ch}
@@ -123,8 +134,10 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
                           backgroundColor: line.responsibilities.includes(ch) ? rasciStyles[ch].bg : 'transparent',
                           color: line.responsibilities.includes(ch) ? 'black' : '#ccc',
                           borderRadius: 4,
-                          border: line.responsibilities.includes(ch) ? `1px solid ${rasciStyles[ch].border}` : '1px solid transparent'
+                          border: line.responsibilities.includes(ch) ? `1px solid ${rasciStyles[ch].border}` : '1px solid transparent',
+                          cursor: onRespClick ? 'pointer' : 'default'
                         }}
+                        onClick={onRespClick ? () => onRespClick(group.team.id, line.roleId, ch) : undefined}
                       >
                         {ch}
                       </span>

--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -184,6 +184,27 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
     setEditorState(RichUtils.toggleBlockType(editorState, type));
   };
 
+  const handleTeamFilter = (teamId) => {
+    setShowFilters(true);
+    setFilterTeam(teamId);
+    setFilterRole('');
+    setFilterResp('');
+  };
+
+  const handleRoleFilter = (teamId, roleId) => {
+    setShowFilters(true);
+    setFilterTeam(teamId);
+    setFilterRole(roleId);
+    setFilterResp('');
+  };
+
+  const handleRespFilter = (teamId, roleId, resp) => {
+    setShowFilters(true);
+    setFilterTeam(teamId);
+    setFilterRole(roleId);
+    setFilterResp(resp);
+  };
+
   React.useEffect(() => {
     const handleMove = (e) => {
       if (!resizing.current || !containerRef.current) return;
@@ -727,6 +748,9 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
               onEdit={openEdit}
               onDelete={handleDelete}
               onTagClick={(id) => { setShowFilters(true); setFilterTags([id]); }}
+              onTeamClick={handleTeamFilter}
+              onRoleClick={handleRoleFilter}
+              onRespClick={handleRespFilter}
               onClose={() => setDetailsOpen(false)}
             />
           </div>


### PR DESCRIPTION
## Summary
- allow filtering nodes when clicking teams, roles or RASCI letters in node details
- pass handlers from `NodeList` to update filters
- change cursor to pointer for clickable elements

## Testing
- `npm test --prefix client --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ebac1db848331ae9fbe2ffafb378e