### PR TITLE
Implement clickable filtering in RASCI view

### DIFF
--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -18,7 +18,7 @@ const rasciStyles = {
   I: { bg: '#bbdefb', border: '#90caf9' }
 };
 
-export default function NodeDetails({ node, attachments, onEdit, onDelete, onTagClick, onClose }) {
+export default function NodeDetails({ node, attachments, onEdit, onDelete, onTagClick, onClose, onTeamClick, onRoleClick, onRespClick }) {
   if (!node) {
     return <div>Selecciona un nodo</div>;
   }
@@ -110,10 +110,21 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
           {rasciByTeam.map(group => (
             <Card key={group.team.id} sx={{ mt: 2 }}>
               <CardContent>
-                <Typography variant="h6">{group.team.order} - {group.team.name}</Typography>
+                <Typography
+                  variant="h6"
+                  onClick={onTeamClick ? () => onTeamClick(group.team.id) : undefined}
+                  sx={{ cursor: onTeamClick ? 'pointer' : 'default' }}
+                >
+                  {group.team.order} - {group.team.name}
+                </Typography>
                 {group.lines.map(line => (
                   <div key={line.id} style={{ display: 'flex', alignItems: 'center', marginTop: '0.5rem' }}>
-                    <span style={{ flex: 1 }}>{line.Role.name}</span>
+                    <span
+                      style={{ flex: 1, cursor: onRoleClick ? 'pointer' : 'default' }}
+                      onClick={onRoleClick ? () => onRoleClick(group.team.id, line.Role.id) : undefined}
+                    >
+                      {line.Role.name}
+                    </span>
                     {['R','A','S','C','I'].map(ch => (
                       <span
                         key={ch}
@@ -123,8 +134,10 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
                           backgroundColor: line.responsibilities.includes(ch) ? rasciStyles[ch].bg : 'transparent',
                           color: line.responsibilities.includes(ch) ? 'black' : '#ccc',
                           borderRadius: 4,
-                          border: line.responsibilities.includes(ch) ? `1px solid ${rasciStyles[ch].border}` : '1px solid transparent'
+                          border: line.responsibilities.includes(ch) ? `1px solid ${rasciStyles[ch].border}` : '1px solid transparent',
+                          cursor: onRespClick ? 'pointer' : 'default'
                         }}
+                        onClick={onRespClick ? () => onRespClick(group.team.id, line.Role.id, ch) : undefined}
                       >
                         {ch}
                       </span>

--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -393,6 +393,27 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
     }
   };
 
+  const handleTeamFilter = (teamId) => {
+    setShowFilters(true);
+    setFilterTeam(teamId);
+    setFilterRole('');
+    setFilterResp('');
+  };
+
+  const handleRoleFilter = (teamId, roleId) => {
+    setShowFilters(true);
+    setFilterTeam(teamId);
+    setFilterRole(roleId);
+    setFilterResp('');
+  };
+
+  const handleRespFilter = (teamId, roleId, resp) => {
+    setShowFilters(true);
+    setFilterTeam(teamId);
+    setFilterRole(roleId);
+    setFilterResp(resp);
+  };
+
   const [moveNode, moving] = useProcessingAction(async (id, direction) => {
     await axios.post(`/api/nodes/${id}/move`, { direction });
     await load();
@@ -576,7 +597,7 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
         </div>
       </div>
       <div ref={containerRef} style={{ flex: 1, display: 'flex', overflow: 'hidden', position: 'relative' }}>
-        <div style={{ width: detailsOpen ? `${leftWidth}%` : '100%', minWidth: 300, padding: '1rem', overflowY: 'auto', borderRight: detailsOpen ? '1px solid #ccc' : 'none' }}>
+        <div style={{ width: detailsOpen ? `${leftWidth}%` : '100%', minWidth: 300, padding: '1rem', overflowY: 'auto', borderRight: detailsOpen ? '1px solid #ccc' : 'none', transition: 'width 0.3s' }}>
           <Tooltip title="Nuevo nodo raíz">
             <IconButton onClick={() => openCreate('')}>
               <AddIcon />
@@ -720,7 +741,7 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
           </div>
         )}
         {detailsOpen ? (
-          <div style={{ width: `${100 - leftWidth}%`, padding: '1rem', overflowY: 'auto' }}>
+          <div style={{ width: `${100 - leftWidth}%`, padding: '1rem', overflowY: 'auto', transition: 'width 0.3s' }}>
             <NodeDetails
               node={viewNode}
               attachments={viewAttachments}
@@ -728,6 +749,9 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
               onDelete={handleDelete}
               onTagClick={(id) => { setShowFilters(true); setFilterTags([id]); }}
               onClose={() => setDetailsOpen(false)}
+              onTeamClick={handleTeamFilter}
+              onRoleClick={handleRoleFilter}
+              onRespClick={handleRespFilter}
             />
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- make team, role and responsibility names clickable in node details
- filter node list based on RASCI clicks
- add smooth width transitions when opening or closing the detail pane

## Testing
- `npm test --unsafe-perm` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ebc1aa5c8833195aa81e7e8c854b3