### PR TITLE
Add Jira export support

### DIFF
--- a/client/src/components/models/JiraExport.jsx
+++ b/client/src/components/models/JiraExport.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import axios from 'axios';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import useProcessingAction from '../../hooks/useProcessingAction';
+
+export default function JiraExport({ open, modelId, onClose }) {
+  const [tab, setTab] = React.useState(0);
+  const [url, setUrl] = React.useState('');
+  const [email, setEmail] = React.useState('');
+  const [token, setToken] = React.useState('');
+  const [projects, setProjects] = React.useState([]);
+  const [projectKey, setProjectKey] = React.useState('');
+  const [log, setLog] = React.useState('');
+
+  React.useEffect(() => {
+    if (open) {
+      axios.get('/api/parameters').then(res => {
+        const p = {};
+        res.data.forEach(pr => { p[pr.name] = pr.value; });
+        setUrl(p['Jira URL'] || '');
+        setEmail(p['Jira usuario'] || '');
+        setToken(p['Jira token'] || '');
+      });
+    } else {
+      setLog('');
+    }
+  }, [open]);
+
+  const [loadProjects, loadingProjects] = useProcessingAction(async () => {
+    const res = await axios.post('/api/jira/projects', { url, email, token });
+    setProjects(res.data);
+  });
+
+  const [runExport, exporting] = useProcessingAction(async () => {
+    if (tab === 0) {
+      window.location = `/api/models/${modelId}/jira-file`;
+    } else {
+      const res = await axios.post(`/api/models/${modelId}/jira-api`, {
+        url,
+        email,
+        token,
+        projectKey,
+      });
+      setLog(res.data.log.join('\n'));
+    }
+  });
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Exportar a Jira</DialogTitle>
+      <DialogContent>
+        <Tabs value={tab} onChange={(_, v) => setTab(v)}>
+          <Tab label="Fichero" />
+          <Tab label="API" />
+        </Tabs>
+        {tab === 0 && (
+          <div style={{ marginTop: '1rem' }}>
+            <Button variant="contained" onClick={runExport} disabled={exporting}>
+              Exportar
+            </Button>
+          </div>
+        )}
+        {tab === 1 && (
+          <div style={{ marginTop: '1rem', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <TextField required label="URL" value={url} onChange={e => setUrl(e.target.value)} />
+            <TextField required label="Usuario" value={email} onChange={e => setEmail(e.target.value)} />
+            <TextField required label="Token" value={token} onChange={e => setToken(e.target.value)} />
+            <Button variant="outlined" onClick={loadProjects} disabled={loadingProjects}>Cargar proyectos</Button>
+            {projects.length > 0 && (
+              <FormControl fullWidth>
+                <InputLabel>Proyecto</InputLabel>
+                <Select label="Proyecto" value={projectKey} onChange={e => setProjectKey(e.target.value)}>
+                  {projects.map(p => (
+                    <MenuItem key={p.key} value={p.key}>{p.name}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+            <Button variant="contained" onClick={runExport} disabled={exporting || !projectKey}>Exportar</Button>
+            {log && (
+              <TextField label="Log" multiline fullWidth value={log} InputProps={{ readOnly: true }} />
+            )}
+          </div>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={exporting || loadingProjects}>Cerrar</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/src/components/models/ModelList.jsx
+++ b/client/src/components/models/ModelList.jsx
@@ -38,12 +38,14 @@ import GroupsIcon from '@mui/icons-material/Groups';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import DescriptionIcon from '@mui/icons-material/Description';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
 import { jsPDF } from 'jspdf';
 import TagList from '../tags/TagList';
 import TeamList from '../teams/TeamList';
 import NodeList from '../nodes/NodeList';
 import DocumentCategoryList from '../documentCategories/DocumentCategoryList';
 import useProcessingAction from '../../hooks/useProcessingAction';
+import JiraExport from './JiraExport';
 
 function csvExport(data) {
   const header = 'Nombre;Autor';
@@ -94,6 +96,7 @@ export default function ModelList({ readOnly = false, initialView = 'table', ena
   const [teamsModel, setTeamsModel] = React.useState(null);
   const [nodesModel, setNodesModel] = React.useState(null);
   const [categoriesModel, setCategoriesModel] = React.useState(null);
+  const [jiraModel, setJiraModel] = React.useState(null);
 
   const load = async () => {
     const res = await axios.get('/api/models');
@@ -154,6 +157,9 @@ export default function ModelList({ readOnly = false, initialView = 'table', ena
   };
   const openNodes = (model) => {
     setNodesModel(model);
+  };
+  const openJira = (model) => {
+    setJiraModel(model);
   };
 
   const filtered = models.filter(m =>
@@ -259,6 +265,11 @@ export default function ModelList({ readOnly = false, initialView = 'table', ena
                           <GroupsIcon />
                         </IconButton>
                       </Tooltip>
+                      <Tooltip title="Exportar a Jira">
+                        <IconButton onClick={() => openJira(model)}>
+                          <UploadFileIcon />
+                        </IconButton>
+                      </Tooltip>
                       {enableNodeEdit && (
                         <Tooltip title="Nodos">
                           <IconButton onClick={() => openNodes(model)}>
@@ -310,6 +321,11 @@ export default function ModelList({ readOnly = false, initialView = 'table', ena
                       <Tooltip title="Equipos y roles">
                         <IconButton onClick={() => openTeams(model)}>
                           <GroupsIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Exportar a Jira">
+                        <IconButton onClick={() => openJira(model)}>
+                          <UploadFileIcon />
                         </IconButton>
                       </Tooltip>
                       {enableNodeEdit && (
@@ -374,6 +390,9 @@ export default function ModelList({ readOnly = false, initialView = 'table', ena
           modelName={nodesModel.name}
           onClose={() => { setNodesModel(null); setView('cards'); }}
         />
+      )}
+      {jiraModel && (
+        <JiraExport open={!!jiraModel} modelId={jiraModel.id} onClose={() => setJiraModel(null)} />
       )}
     </div>
   );

--- a/server/app.js
+++ b/server/app.js
@@ -24,6 +24,7 @@ const roleRoutes = require('./routes/roles');
 const categoriaRoutes = require('./routes/categoriaDocumentos');
 const nodeRoutes = require('./routes/nodes');
 const dataRoutes = require('./routes/data');
+const jiraRoutes = require('./routes/jira');
 
 app.use('/api/models', modelRoutes);
 app.use('/api/parameters', parameterRoutes);
@@ -34,5 +35,6 @@ app.use('/api/models/:modelId/categoria-documentos', categoriaRoutes);
 app.use('/api/models/:modelId/nodes', nodeRoutes);
 app.use('/api/nodes', nodeRoutes);
 app.use('/api/data', dataRoutes);
+app.use('/api/jira', jiraRoutes);
 
 module.exports = { app, db };

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -77,6 +77,21 @@ async function initDatabase(retries = 5, delayMs = 2000) {
         where: { name: 'Nombre de la aplicación' },
         defaults: { value: 'MCM', defaultValue: 'MCM' }
       });
+      await db.Parameter.findOrCreate({
+        where: { name: 'Jira URL' },
+        defaults: {
+          value: 'https://your-domain.atlassian.net',
+          defaultValue: 'https://your-domain.atlassian.net'
+        }
+      });
+      await db.Parameter.findOrCreate({
+        where: { name: 'Jira usuario' },
+        defaults: { value: 'user@example.com', defaultValue: 'user@example.com' }
+      });
+      await db.Parameter.findOrCreate({
+        where: { name: 'Jira token' },
+        defaults: { value: 'changeme', defaultValue: 'changeme' }
+      });
       return;
     } catch (err) {
       if (attempt >= retries) throw err;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.9.0",
         "body-parser": "^2.2.0",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
@@ -74,6 +75,12 @@
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
@@ -81,6 +88,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/body-parser": {
@@ -156,6 +174,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/concat-stream": {
@@ -246,6 +276,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -343,6 +382,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -415,6 +469,63 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -507,6 +618,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -949,6 +1075,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.0",

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "axios": "^1.9.0",
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",

--- a/server/routes/jira.js
+++ b/server/routes/jira.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const axios = require('axios');
+const router = express.Router();
+
+router.post('/projects', async (req, res) => {
+  const { url, email, token } = req.body;
+  try {
+    const auth = Buffer.from(`${email}:${token}`).toString('base64');
+    const response = await axios.get(`${url.replace(/\/$/, '')}/rest/api/3/project/search`, {
+      headers: { Authorization: `Basic ${auth}` }
+    });
+    const projects = (response.data.values || []).map(p => ({ key: p.key, name: p.name }));
+    res.json(projects);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/routes/models.js
+++ b/server/routes/models.js
@@ -1,5 +1,6 @@
 const express = require('express');
-const { Model, Node } = require('../models');
+const { Model, Node, Tag, NodeRasci, Role, Team } = require('../models');
+const axios = require('axios');
 const router = express.Router();
 
 router.get('/', async (req, res) => {
@@ -25,6 +26,72 @@ router.put('/:id', async (req, res) => {
 router.delete('/:id', async (req, res) => {
   await Model.destroy({ where: { id: req.params.id } });
   res.json({});
+});
+
+async function getLeafNodes(modelId) {
+  const nodes = await Node.findAll({
+    where: { modelId },
+    include: [
+      { model: Tag, as: 'tags' },
+      { model: NodeRasci, as: 'rascis', include: { model: Role, include: Team } }
+    ],
+    order: [['parentId', 'ASC'], ['order', 'ASC']]
+  });
+  const parents = new Set(nodes.map(n => n.parentId).filter(id => id));
+  return nodes.filter(n => !parents.has(n.id));
+}
+
+function buildDescription(node) {
+  let text = node.description || '';
+  if (node.tags && node.tags.length) {
+    text += `\nEtiquetas: ${node.tags.map(t => t.name).join(', ')}`;
+  }
+  if (node.rascis && node.rascis.length) {
+    text += '\nRASCI:';
+    node.rascis.forEach(r => {
+      text += `\n- ${r.Role.Team.name} / ${r.Role.name}: ${r.responsibilities}`;
+    });
+  }
+  return text;
+}
+
+router.get('/:id/jira-file', async (req, res) => {
+  const nodes = await getLeafNodes(req.params.id);
+  const lines = nodes.map(n => {
+    const summary = n.name.replace(/"/g, '""');
+    const desc = buildDescription(n).replace(/"/g, '""');
+    return `"${summary}";"${desc}"`;
+  });
+  res.setHeader('Content-Type', 'text/csv');
+  res.setHeader('Content-Disposition', 'attachment; filename="jira.csv"');
+  res.send(['Summary;Description', ...lines].join('\n'));
+});
+
+router.post('/:id/jira-api', async (req, res) => {
+  const { url, email, token, projectKey } = req.body;
+  const nodes = await getLeafNodes(req.params.id);
+  const auth = Buffer.from(`${email}:${token}`).toString('base64');
+  const logs = [];
+  for (const node of nodes) {
+    const issue = {
+      fields: {
+        summary: node.name,
+        description: buildDescription(node),
+        issuetype: { name: 'Task' },
+        project: { key: projectKey }
+      }
+    };
+    try {
+      await axios.post(`${url.replace(/\/$/, '')}/rest/api/3/issue`, issue, {
+        headers: { Authorization: `Basic ${auth}`, 'Content-Type': 'application/json' }
+      });
+      logs.push(`Creado: ${node.name}`);
+    } catch (err) {
+      const msg = err.response?.data?.errorMessages?.join('; ') || err.message;
+      logs.push(`Error ${node.name}: ${msg}`);
+    }
+  }
+  res.json({ log: logs });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add button and dialog to export models to Jira
- create Jira export popup component
- support exporting leaf nodes to CSV or via Jira API
- store Jira connection params
- add Jira project listing API
- include axios dependency

## Testing
- `npm install` within `client`
- `npm run build` within `client`
- `npm install axios@1.9.0 --save` within `server`
- `npm start` within `server` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_684ebe1f488c8331828115f28e495b38