### PR TITLE
Update node RASCI handling

### DIFF
--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -18,7 +18,7 @@ const rasciStyles = {
   I: { bg: '#bbdefb', border: '#90caf9' }
 };
 
-export default function NodeDetails({ node, attachments, onEdit, onDelete, onTagClick, onClose, onTeamClick, onRoleClick, onRespClick }) {
+export default function NodeDetails({ node, attachments, onEdit, onDelete, onTagClick, onClose, onTeamClick, onRoleClick, onRespClick, isLeaf }) {
   if (!node) {
     return <div>Selecciona un nodo</div>;
   }
@@ -104,7 +104,7 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
         </div>
       )}
       <div dangerouslySetInnerHTML={{ __html: node.description }} />
-      {rasciByTeam.length > 0 && (
+      {isLeaf && rasciByTeam.length > 0 && (
         <div style={{ marginTop: '1rem' }}>
           <h3>RASCI</h3>
           {rasciByTeam.map(group => (


### PR DESCRIPTION
## Summary
- clone RASCI lines from parent when a new node is created
- hide RASCI info in node details if the node isn't a leaf
- show RASCI tab only for leaf nodes when editing
- default new child nodes to parent's RASCI

## Testing
- `npm test --prefix client` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684f0d1c208c83319ab2f544848ae643