### PR TITLE
Add help manual page and icon

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,7 @@ import Header from './components/Header';
 import ModelList from './components/models/ModelList';
 // Página de administración
 import AdminPage from './components/AdminPage';
+import HelpPage from './components/HelpPage';
 // Cliente HTTP para peticiones a la API
 import axios from 'axios';
 // Contenedor de Material UI para centrar el contenido
@@ -17,6 +18,8 @@ function App() {
   const [showAdmin, setShowAdmin] = React.useState(false);
   // Estado para controlar la vista de modelos públicos
   const [showPublicModels, setShowPublicModels] = React.useState(false);
+  // Estado para mostrar la ayuda
+  const [showHelp, setShowHelp] = React.useState(false);
   // Nombre de la aplicación mostrado en la cabecera
   const [appName, setAppName] = React.useState('MCM');
 
@@ -37,20 +40,27 @@ function App() {
   React.useEffect(() => { loadName(); }, []);
 
   // Cierra cualquier vista abierta
-  const closeAll = () => { setShowAdmin(false); setShowPublicModels(false); };
+  const closeAll = () => { setShowAdmin(false); setShowPublicModels(false); setShowHelp(false); };
 
   return (
     <div>
       {/* Cabecera con opciones para cambiar de vista */}
       <Header appName={appName}
               onModels={() => { closeAll(); setShowPublicModels(true); }}
-              onAdmin={() => { closeAll(); setShowAdmin(true); }} />
+              onAdmin={() => { closeAll(); setShowAdmin(true); }}
+              onHelp={() => { closeAll(); setShowHelp(true); }} />
       {/* Contenedor principal de la página */}
       <Container sx={{ mt: 2 }}>
         {/* Si se activa la vista de modelos públicos los mostramos */}
         {showPublicModels && <ModelList readOnly initialView="cards" enableNodeEdit />}
         {/* Si estamos en la zona de administración se muestra */}
         {showAdmin && <AdminPage />}
+        {showHelp && (
+          <HelpPage
+            onGoModels={() => { closeAll(); setShowPublicModels(true); }}
+            onGoAdmin={() => { closeAll(); setShowAdmin(true); }}
+          />
+        )}
 
       </Container>
     </div>

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -5,8 +5,9 @@ import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import MenuItem from '@mui/material/MenuItem';
 import SettingsIcon from '@mui/icons-material/Settings';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 
-export default function Header({ appName, onAdmin, onModels }) {
+export default function Header({ appName, onAdmin, onModels, onHelp }) {
   return (
     <AppBar position="static">
       <Toolbar>
@@ -14,6 +15,9 @@ export default function Header({ appName, onAdmin, onModels }) {
           {appName}
         </Typography>
         <MenuItem onClick={onModels}>Modelos</MenuItem>
+        <IconButton color="inherit" onClick={onHelp}>
+          <HelpOutlineIcon />
+        </IconButton>
         <IconButton color="inherit" onClick={onAdmin}>
           <SettingsIcon />
         </IconButton>

--- a/client/src/components/HelpPage.jsx
+++ b/client/src/components/HelpPage.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import Link from '@mui/material/Link';
+
+export default function HelpPage({ onGoModels, onGoAdmin }) {
+  return (
+    <div>
+      <h1>Manual de uso</h1>
+      <p>Bienvenido a la aplicación MCM. Desde aquí podrá gestionar modelos y toda su información asociada.</p>
+
+      <h2 id="inicio">Contenido</h2>
+      <ul>
+        <li><a href="#modelos">Modelos</a></li>
+        <li><a href="#tags">Etiquetas</a></li>
+        <li><a href="#equipos">Equipos y roles</a></li>
+        <li><a href="#nodos">Nodos</a></li>
+        <li><a href="#importacion">Importación y exportación</a></li>
+      </ul>
+
+      <h2 id="modelos">Modelos</h2>
+      <p>Los modelos representan la estructura principal del conocimiento. Puede acceder a la gestión completa desde la zona de administración.</p>
+      <p>
+        <Link component="button" onClick={onGoModels}>Ver modelos públicos</Link>
+        {' | '}
+        <Link component="button" onClick={onGoAdmin}>Administrar modelos</Link>
+      </p>
+
+      <h2 id="tags">Etiquetas</h2>
+      <p>Las etiquetas permiten clasificar los nodos y modelos con colores personalizables.</p>
+
+      <h2 id="equipos">Equipos y roles</h2>
+      <p>Desde cada modelo se pueden definir equipos de trabajo y sus roles asociados.</p>
+
+      <h2 id="nodos">Nodos</h2>
+      <p>Los nodos contienen la información jerárquica del modelo. Puede asignarles etiquetas, adjuntar documentos y definir responsabilidades RASCI.</p>
+
+      <h2 id="importacion">Importación y exportación</h2>
+      <p>En la sección de administración encontrará utilidades para importar y exportar datos, así como la opción de exportar a Jira.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `HelpPage` component with basic manual
- include Help icon in header
- show help page via new state in `App`

## Testing
- `npm test` *(fails: no tests configured)*
- `npm run build` *(fails: duplicate functions in NodeList)*

------
https://chatgpt.com/codex/tasks/task_e_684f0da71b5083318e2b6652d0964743