### PR TITLE
Fix attachment download using UUIDs

### DIFF
--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -5,6 +5,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import { jsPDF } from 'jspdf';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -32,6 +33,19 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
       callback: () => doc.save(`${node.code}.pdf`),
       html2canvas: { scale: 0.8 }
     });
+  };
+
+  const downloadAttachment = async (uuid, name) => {
+    const res = await fetch(`/api/nodes/attachments/download/${uuid}`);
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', name);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
   };
   const rasciByTeam = React.useMemo(() => {
     if (!node.rascis) return [];
@@ -155,8 +169,11 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
           <ul>
             {attachments.map(att => (
               <li key={att.id}>
-                <a href={`/api/nodes/attachments/${att.id}/download`}>{att.name}</a>{' '}
+                {att.name}{' '}
                 (<span>{att.CategoriaDocumento.name}</span>)
+                <IconButton size="small" onClick={() => downloadAttachment(att.uuid, att.name)} sx={{ ml: 1 }}>
+                  <FileDownloadIcon fontSize="inherit" />
+                </IconButton>
               </li>
             ))}
           </ul>

--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -153,6 +153,16 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
     await axios.delete(`/api/nodes/attachments/${id}`);
     loadAttachments(editing.id);
   });
+  const [downloadAttachment] = useProcessingAction(async (uuid, name) => {
+    const res = await axios.get(`/api/nodes/attachments/download/${uuid}`, { responseType: 'blob' });
+    const url = window.URL.createObjectURL(new Blob([res.data]));
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', name);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  });
   const [expanded, setExpanded] = React.useState([]);
   const [selected, setSelected] = React.useState('');
   const [focusNodeId, setFocusNodeId] = React.useState(null);
@@ -1089,10 +1099,15 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
                       {attachments.map(att => (
                         <TableRow key={att.id}>
                           <TableCell>{att.CategoriaDocumento.name}</TableCell>
+                          <TableCell>{att.name}</TableCell>
                           <TableCell>
-                            <a href={`/api/nodes/attachments/${att.id}/download`}>{att.name}</a>
-                          </TableCell>
-                          <TableCell>
+                            <Tooltip title="Descargar" sx={{ mr: 1 }}>
+                              <span>
+                                <IconButton size="small" onClick={() => downloadAttachment(att.uuid, att.name)}>
+                                  <FileDownloadIcon fontSize="inherit" />
+                                </IconButton>
+                              </span>
+                            </Tooltip>
                             <Tooltip title="Eliminar archivo">
                               <span>
                                 <IconButton

--- a/server/models/NodeAttachment.js
+++ b/server/models/NodeAttachment.js
@@ -1,5 +1,11 @@
 module.exports = (sequelize, DataTypes) => {
   return sequelize.define('NodeAttachment', {
+    uuid: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      defaultValue: DataTypes.UUIDV4,
+      unique: true,
+    },
     name: {
       type: DataTypes.STRING,
       allowNull: false,

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -92,6 +92,13 @@ async function initDatabase(retries = 5, delayMs = 2000) {
         where: { name: 'Jira token' },
         defaults: { value: 'changeme', defaultValue: 'changeme' }
       });
+
+      const { v4: uuidv4 } = require('uuid');
+      const atts = await db.NodeAttachment.findAll({ where: { uuid: null } });
+      for (const att of atts) {
+        att.uuid = uuidv4();
+        await att.save();
+      }
       return;
     } catch (err) {
       if (attempt >= retries) throw err;

--- a/server/routes/nodes.js
+++ b/server/routes/nodes.js
@@ -216,8 +216,8 @@ router.post('/:nodeId/attachments', upload.single('file'), async (req, res) => {
   res.json(full);
 });
 
-router.get('/attachments/:id/download', async (req, res) => {
-  const att = await NodeAttachment.findByPk(req.params.id);
+router.get('/attachments/download/:uuid', async (req, res) => {
+  const att = await NodeAttachment.findOne({ where: { uuid: req.params.uuid } });
   if (!att) return res.status(404).end();
   const file = path.join(__dirname, '..', att.filePath);
   if (!fs.existsSync(file)) return res.status(404).end();


### PR DESCRIPTION
## Summary
- add `uuid` field to NodeAttachment model
- populate missing attachment UUIDs on startup
- support downloading attachments by UUID via new route
- expose download button in Node editing UI
- add download button to node details

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f0f5855d083319603a99a7bed3ea4