### PR TITLE
Improve import/export help

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ Con estos pasos la aplicación queda desplegada y lista para usarse.
 
 ## Importación y exportación de datos
 
-Desde la sección de administración se puede descargar un volcado SQL de todos los registros pulsando en **Exportar**. El fichero generado contiene sentencias `INSERT` con actualización automática si el registro ya existe.
+Para utilizar estas herramientas acceda a **Administrar** desde la cabecera y seleccione la pestaña *Importación/Exportación*.
 
-Para importar, seleccione un fichero `.sql` y elija qué entidades cargar. Tras ejecutar la importación se mostrará un log con el resultado de cada sentencia.
+### Exportar
+1. Pulse **Exportar** para generar el fichero `export.sql` con todas las entidades. Si la operación tarda más de un segundo aparecerá el aviso *Procesando...* hasta que finalice.
+2. Cuando termine, el navegador iniciará la descarga del fichero automáticamente.
+
+### Importar
+1. Seleccione un archivo `.sql`. La aplicación analizará su contenido y mostrará la lista de entidades detectadas, todas marcadas por defecto.
+2. Puede desmarcar las que no desee cargar y pulsar **Ejecutar importación**. Mientras se ejecuta verá el aviso *Procesando...*.
+3. Al finalizar se mostrará un registro con el resultado de cada sentencia ejecutada.
+
+El fichero exportado contiene sentencias `INSERT` que actualizan registros existentes mediante `ON DUPLICATE KEY UPDATE`.

--- a/client/src/components/HelpPage.jsx
+++ b/client/src/components/HelpPage.jsx
@@ -34,7 +34,28 @@ export default function HelpPage({ onGoModels, onGoAdmin }) {
       <p>Los nodos contienen la información jerárquica del modelo. Puede asignarles etiquetas, adjuntar documentos y definir responsabilidades RASCI.</p>
 
       <h2 id="importacion">Importación y exportación</h2>
-      <p>En la sección de administración encontrará utilidades para importar y exportar datos, así como la opción de exportar a Jira.</p>
+      <p>
+        Acceda a estas funciones desde la cabecera pulsando
+        <strong>Administrar</strong> y elija la pestaña
+        <em>Importación/Exportación</em>.
+      </p>
+      <p>
+        Para <strong>exportar</strong> simplemente haga clic en el botón
+        <em>Exportar</em>. Se generará el fichero
+        <code>export.sql</code> y la descarga comenzará de forma
+        automática. Si la operación dura más de un segundo verá en la
+        parte superior el aviso <em>Procesando...</em> con el tiempo
+        transcurrido hasta que finalice.
+      </p>
+      <p>
+        Para <strong>importar</strong> seleccione un archivo
+        <code>.sql</code>. El sistema mostrará la lista de entidades
+        detectadas y podrá marcar o desmarcar las que desee cargar.
+        Pulse <em>Ejecutar importación</em> para iniciar el proceso. Al
+        terminar, aparecerá un registro con el resultado de cada
+        sentencia ejecutada.
+      </p>
+      <p>Desde este apartado también puede lanzar la exportación a Jira.</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- expand section on export/import in help page
- flesh out README instructions about export/import

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f155dfbb88331b0a9184e378f6168