### PR TITLE
Fix attachment filename extension on download

### DIFF
--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -40,9 +40,13 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
     if (!res.ok) return;
     const blob = await res.blob();
     const url = window.URL.createObjectURL(blob);
+    const disposition = res.headers.get('content-disposition') || '';
+    let filename = name;
+    const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+    if (match) filename = match[1].replace(/['"]/g, '');
     const link = document.createElement('a');
     link.href = url;
-    link.setAttribute('download', name);
+    link.setAttribute('download', filename);
     document.body.appendChild(link);
     link.click();
     link.remove();

--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -157,9 +157,13 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
   const [downloadAttachment] = useProcessingAction(async (uuid, name) => {
     const res = await axios.get(`/api/nodes/attachments/download/${uuid}`, { responseType: 'blob' });
     const url = window.URL.createObjectURL(new Blob([res.data]));
+    const disposition = res.headers['content-disposition'] || '';
+    let filename = name;
+    const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+    if (match) filename = match[1].replace(/['"]/g, '');
     const link = document.createElement('a');
     link.href = url;
-    link.setAttribute('download', name);
+    link.setAttribute('download', filename);
     document.body.appendChild(link);
     link.click();
     link.remove();

--- a/server/routes/nodes.js
+++ b/server/routes/nodes.js
@@ -221,7 +221,9 @@ router.get('/attachments/download/:uuid', async (req, res) => {
   if (!att) return res.status(404).end();
   const file = path.join(__dirname, '..', att.filePath);
   if (!fs.existsSync(file)) return res.status(404).end();
-  res.download(file, att.name);
+  const ext = path.extname(att.filePath);
+  const name = att.name.endsWith(ext) ? att.name : att.name + ext;
+  res.download(file, name);
 });
 
 router.delete('/attachments/:id', async (req, res) => {


### PR DESCRIPTION
## Summary
- preserve original extension when downloading attachments from server
- parse filename from download header in client for NodeList and NodeDetails

## Testing
- `npm test --silent` (no tests configured)
- `cd server && npm test --silent` (no tests configured)
- `cd client && npm test --silent` (no tests configured)


------
https://chatgpt.com/codex/tasks/task_e_684f1835d00483319504ea55ce6ee018