### PR TITLE
Fix Tag editing endpoint

### DIFF
--- a/client/src/components/tags/TagList.jsx
+++ b/client/src/components/tags/TagList.jsx
@@ -77,7 +77,7 @@ export default function TagList({ modelId, open, onClose }) {
 
   const [save, saving] = useProcessingAction(async () => {
     if (editing) {
-      await axios.put(`/api/tags/${editing.id}`, form);
+      await axios.put(`/api/models/${modelId}/tags/${editing.id}`, form);
     } else {
       await axios.post(`/api/models/${modelId}/tags`, form);
     }
@@ -88,7 +88,7 @@ export default function TagList({ modelId, open, onClose }) {
   });
 
   const [remove, removing] = useProcessingAction(async (id) => {
-    await axios.delete(`/api/tags/${id}`);
+    await axios.delete(`/api/models/${modelId}/tags/${id}`);
     load();
   });
 


### PR DESCRIPTION
## Summary
- fix path to update/delete tags with modelId

## Testing
- `npm run build` in `client`
- `npm start` in `server` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684f1ae077988331a57d1801ce7ea3fd