### PR TITLE
Add bold/underline options to nodes

### DIFF
--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -123,7 +123,7 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
   const [nodes, setNodes] = React.useState([]);
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [editing, setEditing] = React.useState(null);
-  const [form, setForm] = React.useState({ parentId: '', code: '', name: '', patternType: 'order', patternText: '', description: '' });
+  const [form, setForm] = React.useState({ parentId: '', code: '', name: '', patternType: 'order', patternText: '', description: '', bold: false, underline: false });
   const [showFilters, setShowFilters] = React.useState(false);
   const [filter, setFilter] = React.useState('');
   const [tags, setTags] = React.useState([]);
@@ -413,6 +413,8 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
       parentId: form.parentId || null,
       codePattern: form.patternType === 'text' ? form.patternText.toUpperCase() : 'ORDER',
       description: form.description,
+      bold: form.bold,
+      underline: form.underline,
       tagIds: selectedTags,
       rasci: rasciLines.map(l => ({ roleId: l.roleId, responsibilities: l.responsibilities }))
     };
@@ -423,7 +425,7 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
       res = await axios.post(`/api/models/${modelId}/nodes`, payload);
     }
     setDialogOpen(false);
-    setForm({ parentId: '', code: '', name: '', patternType: 'order', patternText: '', description: '' });
+    setForm({ parentId: '', code: '', name: '', patternType: 'order', patternText: '', description: '', bold: false, underline: false });
     setSelectedTags([]);
     setRasciLines([]);
     setEditing(null);
@@ -458,7 +460,9 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
       name: node.name,
       patternType: node.codePattern === 'ORDER' ? 'order' : 'text',
       patternText: node.codePattern === 'ORDER' ? '' : node.codePattern,
-      description: node.description || ''
+      description: node.description || '',
+      bold: !!node.bold,
+      underline: !!node.underline
     });
     const parent = nodes.find(n => n.id === node.parentId);
     const inherited = parent && parent.tags ? parent.tags.map(t => t.id) : [];
@@ -483,7 +487,7 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
   const openCreate = async (parentId = '') => {
     setEditing(null);
     setEditingLeaf(true);
-    setForm({ parentId, code: '', name: '', patternType: 'order', patternText: '', description: '' });
+    setForm({ parentId, code: '', name: '', patternType: 'order', patternText: '', description: '', bold: false, underline: false });
     const parent = nodes.find(n => n.id === parentId);
     const inherited = parent && parent.tags ? parent.tags.map(t => t.id) : [];
     setInheritedTags(inherited);
@@ -546,7 +550,15 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
           label={
             <div style={{ display: 'flex', alignItems: 'center' }}>
               <strong style={{ marginRight: '0.25rem' }}>[{n.code}]</strong>
-              <span style={{ marginRight: '0.5rem' }}>{n.name}</span>
+              <span
+                style={{
+                  marginRight: '0.5rem',
+                  fontWeight: n.bold ? 'bold' : 'normal',
+                  textDecoration: n.underline ? 'underline' : 'none'
+                }}
+              >
+                {n.name}
+              </span>
 
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 {n.tags && n.tags.map(tag => (
@@ -921,6 +933,16 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
                 ))}
               </Select>
             </FormControl>
+            <div style={{ display: 'flex', gap: '1rem', marginTop: '1rem' }}>
+              <FormControlLabel
+                control={<Checkbox checked={form.bold} onChange={e => setForm({ ...form, bold: e.target.checked })} />}
+                label="Nombre en negrita"
+              />
+              <FormControlLabel
+                control={<Checkbox checked={form.underline} onChange={e => setForm({ ...form, underline: e.target.checked })} />}
+                label="Nombre subrayado"
+              />
+            </div>
             </div>) }
             {tab === 1 && (
             <div style={{ marginTop: '1rem', flex: 1, display: 'flex', flexDirection: 'column' }}>

--- a/server/models/Node.js
+++ b/server/models/Node.js
@@ -24,6 +24,16 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       defaultValue: '',
     },
+    bold: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    underline: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
     modelId: {
       type: DataTypes.INTEGER,
       allowNull: false,


### PR DESCRIPTION
## Summary
- add `bold` and `underline` fields to Node model
- expose new formatting fields on node editor
- allow styling node names in the tree view

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f1cefe2848331a07894821d4c92f9