### PR TITLE
Add breadcrumb navigation for node details

### DIFF
--- a/client/src/components/nodes/NodeDetails.jsx
+++ b/client/src/components/nodes/NodeDetails.jsx
@@ -6,6 +6,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import HomeIcon from '@mui/icons-material/Home';
 import { jsPDF } from 'jspdf';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -19,7 +20,7 @@ const rasciStyles = {
   I: { bg: '#bbdefb', border: '#90caf9' }
 };
 
-export default function NodeDetails({ node, attachments, onEdit, onDelete, onTagClick, onClose, onTeamClick, onRoleClick, onRespClick, isLeaf }) {
+export default function NodeDetails({ node, attachments, path = [], onEdit, onDelete, onTagClick, onClose, onTeamClick, onRoleClick, onRespClick, onPathClick, isLeaf }) {
   if (!node) {
     return <div>Selecciona un nodo</div>;
   }
@@ -100,6 +101,22 @@ export default function NodeDetails({ node, attachments, onEdit, onDelete, onTag
           )}
         </div>
       </div>
+      {path.length > 0 && (
+        <div style={{ margin: '0.5rem 0', display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+          <HomeIcon fontSize="small" sx={{ mr: 0.5 }} />
+          {path.map((p, idx) => (
+            <React.Fragment key={p.id}>
+              <span
+                onClick={onPathClick ? () => onPathClick(p.id) : undefined}
+                style={{ cursor: onPathClick ? 'pointer' : 'default' }}
+              >
+                [{p.code}] {p.name}
+              </span>
+              {idx < path.length - 1 && <span style={{ margin: '0 0.25rem' }}>{'>'}</span>}
+            </React.Fragment>
+          ))}
+        </div>
+      )}
       <div ref={contentRef}>
       {node.tags && node.tags.length > 0 && (
         <div style={{ marginBottom: '1rem' }}>

--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -165,6 +165,7 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
   const [attachments, setAttachments] = React.useState([]);
   const [viewNode, setViewNode] = React.useState(null);
   const [viewAttachments, setViewAttachments] = React.useState([]);
+  const [viewPath, setViewPath] = React.useState([]);
   const [attForm, setAttForm] = React.useState({ categoryId: '', name: '', file: null });
   const [addAttachment, addingAttachment] = useProcessingAction(async () => {
     if (!attForm.file) return;
@@ -261,6 +262,10 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
     setFilterTeam(teamId);
     setFilterRole(roleId);
     setFilterResp(resp);
+  };
+
+  const handlePathClick = (id) => {
+    setFocusNodeId(id);
   };
 
   React.useEffect(() => {
@@ -420,6 +425,21 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
       setViewAttachments([]);
     }
   }, [viewNode]);
+
+  React.useEffect(() => {
+    if (viewNode) {
+      const map = Object.fromEntries(nodes.map(n => [n.id, n]));
+      let current = viewNode;
+      const path = [];
+      while (current) {
+        path.unshift({ id: current.id, code: current.code, name: current.name });
+        current = current.parentId ? map[current.parentId] : null;
+      }
+      setViewPath(path);
+    } else {
+      setViewPath([]);
+    }
+  }, [viewNode, nodes]);
 
   React.useEffect(() => { if (open) { load(); loadCategories(); } }, [open]);
 
@@ -835,6 +855,8 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
             <NodeDetails
               node={viewNode}
               attachments={viewAttachments}
+              path={viewPath}
+              onPathClick={handlePathClick}
               isLeaf={viewNode ? !nodes.some(n => n.parentId === viewNode.id) : true}
               onEdit={openEdit}
               onDelete={handleDelete}


### PR DESCRIPTION
## Summary
- show breadcrumbs in node details
- compute path in NodeList and handle breadcrumb clicks

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f237d70348331b0497e54c436d857