### PR TITLE
Fix RASCI filter logic

### DIFF
--- a/client/src/components/nodes/NodeList.jsx
+++ b/client/src/components/nodes/NodeList.jsx
@@ -576,11 +576,15 @@ export default function NodeList({ modelId, modelName, open, onClose }) {
       const matchesText = !filter || n.name.toLowerCase().includes(filter.toLowerCase());
       const matchesTags = filterTags.length === 0 || (n.tags && filterTags.every(tagId => n.tags.some(t => t.id === tagId)));
       const matchesRasci = !rasciFiltering || (
-        isLeaf && n.rascis && n.rascis.some(r =>
-          (!filterTeam || r.Role.teamId === filterTeam) &&
-          (!filterRole || r.roleId === filterRole) &&
-          (!filterResp || r.responsibilities.includes(filterResp))
-        )
+        isLeaf && n.rascis && n.rascis.some(r => {
+          const teamOk = !filterTeam || r.Role.teamId === filterTeam;
+          const roleOk = !filterRole || r.roleId === filterRole;
+          const respOk = !filterResp || r.responsibilities.includes(filterResp);
+          const hasResp = (filterTeam || filterRole)
+            ? r.responsibilities && r.responsibilities.length > 0
+            : true;
+          return teamOk && roleOk && respOk && hasResp;
+        })
       );
       if (matchesText && matchesTags && matchesRasci) {
         let current = n;


### PR DESCRIPTION
## Summary
- ensure RASCI filter by team or role only returns nodes with at least one responsibility selected

## Testing
- `npm test` in `client` *(fails: Missing script)*
- `npm test` in `server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f2e5ad560833197c65a1e5e513844