### PR TITLE
Add safe ID handling for XML import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ client/node_modules
 server/node_modules
 .env
 client/dist
+export/*.sql

--- a/export/README.md
+++ b/export/README.md
@@ -1,1 +1,11 @@
 
+Generación de script SQL a partir del fichero XML ubicado en `import`.
+
+Ejecutar desde la raíz del repositorio:
+
+```
+cd server
+npm run xml2sql
+```
+
+El archivo `import.sql` se creará en esta carpeta `export` y podrá cargarse en la aplicación mediante la función de Importación. El script calcula los identificadores partiendo del máximo existente en cada tabla para evitar colisiones.

--- a/import/README.md
+++ b/import/README.md
@@ -1,1 +1,3 @@
+Coloque aquí los ficheros XML de actividades que desee transformar a SQL.
 
+Por defecto el script busca `actividades.BACKUP MCMI.xml` y genera `export/import.sql`.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,10 +14,12 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "he": "^1.2.0",
         "mariadb": "^3.4.2",
         "multer": "^1.4.5-lts.1",
         "mysql2": "^3.14.1",
-        "sequelize": "^6.37.7"
+        "sequelize": "^6.37.7",
+        "xml2js": "^0.4.23"
       }
     },
     "node_modules/@types/debug": {
@@ -652,6 +654,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1190,6 +1201,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -1531,6 +1548,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "xml2sql": "node utils/xmlToSql.js"
   },
   "keywords": [],
   "author": "",
@@ -16,9 +17,11 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "he": "^1.2.0",
     "mariadb": "^3.4.2",
     "multer": "^1.4.5-lts.1",
     "mysql2": "^3.14.1",
-    "sequelize": "^6.37.7"
+    "sequelize": "^6.37.7",
+    "xml2js": "^0.4.23"
   }
 }

--- a/server/utils/xmlToSql.js
+++ b/server/utils/xmlToSql.js
@@ -1,0 +1,152 @@
+const fs = require('fs');
+const path = require('path');
+const xml2js = require('xml2js');
+const he = require('he');
+
+async function parseFile(inputPath) {
+  const xml = fs.readFileSync(inputPath, 'utf8');
+  const data = await xml2js.parseStringPromise(xml, { trim: true });
+  return data.Actividades.Actividad || [];
+}
+
+function decode(value) {
+  if (!value) return '';
+  if (Array.isArray(value)) value = value[0];
+  return he.decode(String(value).trim());
+}
+
+function sanitize(str) {
+  return String(str).replace(/[^a-zA-Z0-9]/g, '');
+}
+
+function initCounters() {
+  return `-- Initialize counters\n` +
+    `SET @model_id := (SELECT COALESCE(MAX(id),0) FROM \`Models\`);\n` +
+    `SET @team_id := (SELECT COALESCE(MAX(id),0) FROM \`Teams\`);\n` +
+    `SET @role_id := (SELECT COALESCE(MAX(id),0) FROM \`Roles\`);\n` +
+    `SET @node_id := (SELECT COALESCE(MAX(id),0) FROM \`Nodes\`);\n` +
+    `SET @rasci_id := (SELECT COALESCE(MAX(id),0) FROM \`NodeRascis\`);\n\n`;
+}
+
+function buildInserts(entity, rows, counter) {
+  if (!rows.length) return '';
+  const cols = Object.keys(rows[0]).filter(c => !['id','var','teamVar','parentVar','modelVar'].includes(c));
+  const colList = cols.map(c => `\`${c}\``).join(', ');
+  let sql = `-- ${entity}\n`;
+  for (const row of rows) {
+    sql += `SET @${counter} := @${counter} + 1;\n`;
+    if (row.var) sql += `SET @${row.var} := @${counter};\n`;
+    const vals = cols.map(c => {
+      if (c === 'teamId' && row.teamVar) return `@${row.teamVar}`;
+      if (c === 'parentId' && row.parentVar) return `@${row.parentVar}`;
+      if (c === 'modelId' && row.modelVar) return `@${row.modelVar}`;
+      return row[c] === null ? 'NULL' : JSON.stringify(row[c]);
+    }).join(', ');
+    sql += `INSERT INTO \`${entity}\` (id, ${colList}) VALUES (@${counter}, ${vals});\n`;
+  }
+  sql += '\n';
+  return sql;
+}
+
+function buildRascis(rows) {
+  if (!rows.length) return '';
+  let sql = `-- NodeRascis\n`;
+  for (const row of rows) {
+    sql += `SET @rasci_id := @rasci_id + 1;\n`;
+    sql += `INSERT INTO \`NodeRascis\` (id, nodeId, roleId, responsibilities) VALUES (@rasci_id, @${row.nodeVar}, @${row.roleVar}, ${row.responsibilities ? JSON.stringify(row.responsibilities) : 'NULL'});\n`;
+  }
+  sql += '\n';
+  return sql;
+}
+
+async function main() {
+  const input = process.argv[2] || path.join(__dirname, '..', '..', 'import', 'actividades.BACKUP MCMI.xml');
+  const output = process.argv[3] || path.join(__dirname, '..', '..', 'export', 'import.sql');
+  const actividades = await parseFile(input);
+
+  const teams = new Map();
+  const roles = new Map();
+  const nodes = new Map();
+  const rascis = [];
+
+  let teamId = 1;
+  let roleId = 1;
+  let nodeId = 1;
+  const orderCounters = new Map();
+
+  function ensureNode(pathArr, name, desc) {
+    const key = pathArr.join('-');
+    if (!nodes.has(key)) {
+      const parentKey = pathArr.slice(0, -1).join('-');
+      const parent = nodes.get(parentKey);
+      const order = (orderCounters.get(parentKey) || 0) + 1;
+      orderCounters.set(parentKey, order);
+      const code = parent ? `${parent.code}.${order}` : String(order);
+      const id = nodeId++;
+      const node = {
+        id,
+        var: `n${id}`,
+        name,
+        description: desc,
+        order,
+        codePattern: 'ORDER',
+        code,
+        bold: false,
+        underline: false,
+        modelId: null,
+        modelVar: 'model_import',
+        parentId: parent ? parent.id : null,
+        parentVar: parent ? parent.var : null,
+      };
+      nodes.set(key, node);
+    }
+    return nodes.get(key);
+  }
+
+  for (const act of actividades) {
+    const name = decode(act.Nombre_Tarea);
+    const edt = decode(act.EDT);
+    const desc = decode(act.Notas);
+    const pathArr = edt.split('-').filter(Boolean);
+    if (!pathArr.length) continue;
+    const node = ensureNode(pathArr, name, desc);
+    const rasciList = (act.MatrizRASCI && act.MatrizRASCI[0].rasci) || [];
+    for (const r of rasciList) {
+      const rolText = decode(r.rol);
+      const resp = decode(r.responsabilidad);
+      if (!rolText) continue;
+      const [teamName, roleName] = rolText.split('_');
+      if (!teamName || !roleName) continue;
+      let team = teams.get(teamName);
+      if (!team) {
+        const id = teamId++;
+        team = { id, var: `t_${sanitize(teamName)}`, name: teamName, order: teams.size + 1, modelId: null, modelVar: 'model_import' };
+        teams.set(teamName, team);
+      }
+      const roleKey = `${teamName}_${roleName}`;
+      let role = roles.get(roleKey);
+      if (!role) {
+        const count = Array.from(roles.values()).filter(ro => ro.teamId === team.id).length;
+        const id = roleId++;
+        role = { id, var: `r_${sanitize(teamName)}_${sanitize(roleName)}`, name: roleName, order: count + 1, teamId: null, teamVar: team.var };
+        roles.set(roleKey, role);
+      }
+      rascis.push({ nodeVar: node.var, roleVar: role.var, responsibilities: resp });
+    }
+  }
+
+  const model = { id: 1, var: 'model_import', name: 'Modelo importado', author: 'import', parentId: null };
+
+  let sql = '';
+  sql += initCounters();
+  sql += buildInserts('Models', [model], 'model_id');
+  sql += buildInserts('Teams', Array.from(teams.values()), 'team_id');
+  sql += buildInserts('Roles', Array.from(roles.values()), 'role_id');
+  sql += buildInserts('Nodes', Array.from(nodes.values()), 'node_id');
+  sql += buildRascis(rascis);
+
+  fs.writeFileSync(output, sql);
+  console.log('SQL generated at', output);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- ensure XML to SQL conversion avoids primary-key collisions by using runtime counters
- allow referencing generated IDs through SQL variables for relationships
- document that the import script calculates IDs based on existing data

## Testing
- `node server/utils/xmlToSql.js`

------
https://chatgpt.com/codex/tasks/task_e_6851deba8be08331920348c9ca980f8d