### PR TITLE
Fix insert script output for import

### DIFF
--- a/server/utils/xmlToSql.js
+++ b/server/utils/xmlToSql.js
@@ -21,7 +21,7 @@ function buildInserts(entity, rows) {
   if (!rows.length) return '';
   const cols = Object.keys(rows[0]).filter(c => c !== 'id');
   const colList = cols.map(c => `\`${c}\``).join(', ');
-  let sql = `-- ${entity}\n`;
+  let sql = `-- Entity: ${entity}\n`;
   for (const row of rows) {
     const vals = cols.map(c => row[c] === null ? 'NULL' : JSON.stringify(row[c])).join(', ');
     sql += `INSERT INTO \`${entity}\` (id, ${colList}) VALUES (${row.id}, ${vals});\n`;


### PR DESCRIPTION
## Summary
- add `-- Entity:` prefix to generated SQL sections

## Testing
- `npm install` (server dependencies)
- `node utils/xmlToSql.js ../import/actividades.BACKUP\ MCMI.xml ../export/import.sql` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6851e74d7c188331903ba89f3d7179fd