### PR TITLE
Add model visibility

### DIFF
--- a/server/models/Model.js
+++ b/server/models/Model.js
@@ -8,6 +8,11 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
     },
+    isPublic: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
     parentId: {
       type: DataTypes.INTEGER,
       allowNull: true,

--- a/server/routes/models.js
+++ b/server/routes/models.js
@@ -9,7 +9,13 @@ router.get('/', async (req, res) => {
 });
 
 router.post('/', async (req, res) => {
-  const model = await Model.create(req.body);
+  const { name, author, parentId, isPublic } = req.body;
+  const model = await Model.create({
+    name,
+    author,
+    parentId,
+    isPublic,
+  });
   await Node.create({ name: 'Raiz', modelId: model.id, parentId: null });
   res.json(model);
 });
@@ -18,7 +24,8 @@ router.put('/:id', async (req, res) => {
   if (req.body.parentId && parseInt(req.body.parentId) === parseInt(req.params.id)) {
     return res.status(400).json({ error: 'Un modelo no puede ser su propio padre' });
   }
-  await Model.update(req.body, { where: { id: req.params.id } });
+  const { name, author, parentId, isPublic } = req.body;
+  await Model.update({ name, author, parentId, isPublic }, { where: { id: req.params.id } });
   const model = await Model.findByPk(req.params.id);
   res.json(model);
 });


### PR DESCRIPTION
## Summary
- add boolean field `isPublic` to server model
- update model routes to handle visibility data
- update ModelList UI to edit public/private and show icon on cards
- export visibility in CSV/PDF

## Testing
- `npm run build` in `client`
- `node index.js` in `server` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6851f1d84168833197ed3b60ed0ac3fd