### PR TITLE
Fix DB timeout by enlarging connection pool

### DIFF
--- a/server/models/index.js
+++ b/server/models/index.js
@@ -10,6 +10,12 @@ const sequelize = new Sequelize(
     host: process.env.DB_HOST || 'localhost',
     port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 3306,
     dialect: 'mariadb',
+    pool: {
+      max: parseInt(process.env.DB_POOL_MAX || '20', 10),
+      min: 0,
+      acquire: 30000,
+      idle: 10000,
+    },
   }
 );
 


### PR DESCRIPTION
## Summary
- configure Sequelize pool in server models

## Testing
- `npm test --prefix server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851f93513548331b21d0b84d495cce4