### PR TITLE
Fix Docker index.js location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY --from=build-server /app ./
 COPY --from=build-web /app/client/dist ./public
 ENV NODE_ENV=production
 EXPOSE 3001
-CMD ["node", "server/index.js"]
+CMD ["node", "index.js"]


### PR DESCRIPTION
## Summary
- correct the Dockerfile entrypoint path

## Testing
- `node server/index.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6862fe6aef5883319d939729a261ea6e