### PR TITLE
Fix wildcard route for Express 5

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -60,7 +60,10 @@ app.use('/uploads', express.static(uploadDir));
 const frontendDir = path.join(__dirname, 'public');
 if (fs.existsSync(frontendDir)) {
   app.use(express.static(frontendDir));
-  app.get('*', (req, res, next) => {
+  // Express 5 with path-to-regexp v8 doesn't accept '*' as a route
+  // pattern. Using a named wildcard avoids the "Missing parameter name"
+  // error when starting the server.
+  app.get('/*splat', (req, res, next) => {
     if (req.path.startsWith('/api/') || req.path.startsWith('/uploads')) {
       return next();
     }


### PR DESCRIPTION
## Summary
- update wildcard catch-all route in server to avoid path-to-regexp error

## Testing
- `npm start` *(fails: ConnectionRefusedError - database not running)*

------
https://chatgpt.com/codex/tasks/task_e_6863011da38c8331bbac783e6e024678