### PR TITLE
Fix DB host for docker compose

### DIFF
--- a/Despliegue.md
+++ b/Despliegue.md
@@ -28,6 +28,7 @@ A continuación se describen todos los pasos necesarios para ejecutar la aplicac
    ```bash
    cp server/.env.example server/.env
    # Edita server/.env con un editor de texto para ajustar las contraseñas
+   # Si usas Docker Compose establece DB_HOST=db
    ```
 4. Desplegar en la carpeta mcm-main el archivo de docker-compose.yml configurado con las credenciales de acceso a base de datos.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Esta guía explica cómo poner en marcha la aplicación desde cero en un servido
    DB_NAME=mcm
    DB_USER=mcm
    DB_PASSWORD=clave_segura
-   DB_HOST=localhost
+   DB_HOST=localhost   # usa "db" si la base de datos se ejecuta con Docker Compose
    # Puerto por defecto de MariaDB/MySQL. Cambiar si se usa otro
    DB_PORT=3306
    ENV

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,7 +2,7 @@
 DB_NAME=mcm
 DB_USER=mcm
 DB_PASSWORD=clave_segura
-DB_HOST=localhost
+DB_HOST=db # usar "localhost" si la base de datos se ejecuta fuera de Docker
 DB_PORT=3306
 USE_AUTH=false
 SESSION_SECRET=mcm-secret


### PR DESCRIPTION
## Summary
- clarify DB host setting in README and Docker deployment instructions
- set DB_HOST to `db` in example env file for containers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863034907cc833194d139ff8b12f808