### PR TITLE
Clarify DB credentials and use env vars

### DIFF
--- a/Despliegue.md
+++ b/Despliegue.md
@@ -7,9 +7,9 @@ Este documento resume cómo poner en marcha la aplicación MCM tanto de forma ma
 Los pasos detallados se encuentran en `README.md`. En resumen:
 
 1. Instalar Node.js, npm y MariaDB.
-2. Crear la base de datos `mcm` y el usuario correspondiente.
+2. Crear la base de datos `mcm` y un usuario `mcm` asignándole la contraseña que prefieras (la necesitaremos después).
 3. Clonar el repositorio y ejecutar `npm install` en `server` y `client`.
-4. Configurar las variables de entorno en `server/.env` siguiendo el ejemplo `server/.env.example`.
+4. Copiar `server/.env.example` a `server/.env` y editarlo para introducir la contraseña elegida en la variable `DB_PASSWORD` (y opcionalmente `DB_ROOT_PASSWORD`).
 5. Lanzar la API con `npm start` y el cliente con `npm run dev` (o `npm run build` para producción).
 
 ## 2. Despliegue con Docker Desktop
@@ -24,14 +24,16 @@ A continuación se describen todos los pasos necesarios para ejecutar la aplicac
    git clone <URL_DEL_REPOSITORIO> mcm
    cd mcm
    ```
-3. Copiar el archivo de ejemplo de variables de entorno y editarlo según tus necesidades:
+3. Copiar el archivo de ejemplo de variables de entorno y editarlo:
    ```bash
    cp server/.env.example server/.env
-   # Edita server/.env con un editor de texto para ajustar las contraseñas
+   # Establece en DB_PASSWORD la misma contraseña empleada al crear el usuario
+   # mcm. Docker Compose usará estas variables automáticamente.
    # Si usas Docker Compose establece DB_HOST=db
-   # Si desplegas la bd sin contenedores estable DB_HOST=localhost
+   # Si desplegas la bd sin contenedores pon DB_HOST=localhost
    ```
-4. Desplegar en la carpeta mcm-main el archivo de docker-compose.yml configurado con las credenciales de acceso a base de datos.
+4. Verifica que `docker-compose.yml` apunte al archivo `server/.env` para que
+   la base de datos y la aplicación compartan las mismas credenciales.
 
 ### 2.2 Puesta en marcha
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Esta guía explica cómo poner en marcha la aplicación desde cero en un servido
 3. **Preparar la base de datos**
    ```sql
    CREATE DATABASE mcm CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-   CREATE USER 'mcm'@'localhost' IDENTIFIED BY 'clave_segura';
+   -- Sustituye <TU_CONTRASENA> por la contraseña que quieras utilizar
+   CREATE USER 'mcm'@'localhost' IDENTIFIED BY '<TU_CONTRASENA>';
    GRANT ALL PRIVILEGES ON mcm.* TO 'mcm'@'localhost';
    FLUSH PRIVILEGES;
    ```
@@ -40,12 +41,19 @@ Esta guía explica cómo poner en marcha la aplicación desde cero en un servido
    cat <<'ENV' > .env
    DB_NAME=mcm
    DB_USER=mcm
-   DB_PASSWORD=clave_segura
+   # Usa la misma contraseña definida al crear el usuario en MariaDB
+   DB_PASSWORD=<TU_CONTRASENA>
+   DB_ROOT_PASSWORD=rootpass
    DB_HOST=localhost   # usa "db" si la base de datos se ejecuta con Docker Compose. Usa "localhost" si se despliega la bd sin contenedores
    # Puerto por defecto de MariaDB/MySQL. Cambiar si se usa otro
    DB_PORT=3306
    ENV
    cd ..
+   ```
+
+   Esta contraseña se reutiliza por Docker para crear la base de datos
+   inicial, por lo que cualquier cambio debe reflejarse tanto en el script
+   de creación como en este archivo.
    ```
 6. **Preparar el cliente**
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,13 @@ services:
   db:
     image: mariadb:11
     restart: always
+    env_file:
+      - server/.env
     environment:
-      MYSQL_DATABASE: mcm
-      MYSQL_USER: mcm
-      MYSQL_PASSWORD: clave_segura
-      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-rootpass}
     volumes:
       - dbdata:/var/lib/mysql
     ports:

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,6 +2,7 @@
 DB_NAME=mcm
 DB_USER=mcm
 DB_PASSWORD=clave_segura
+DB_ROOT_PASSWORD=rootpass
 DB_HOST=db # usar "localhost" si la base de datos se ejecuta fuera de Docker. Usar "db" si se usa Docker Compose para el despliegue
 DB_PORT=3306
 USE_AUTH=false


### PR DESCRIPTION
## Summary
- parametrize database credentials in `docker-compose.yml`
- document how to choose a password for user `mcm`
- extend `.env.example` with `DB_ROOT_PASSWORD`
- update deployment guides to use the chosen password consistently

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68630642b6088331a45c4bd3a18fa4c2