### PR TITLE
Improve DB startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,10 @@ A continuación se describen todos los pasos necesarios para ejecutar la aplicac
    cp server/.env.example server/.env
    # Establece en DB_PASSWORD la misma contraseña empleada al crear el usuario
    # mcm. Docker Compose usará estas variables automáticamente.
-   # Si usas Docker Compose establece DB_HOST=db
-   # Si desplegas la bd sin contenedores pon DB_HOST=localhost
+   # Usa siempre el nombre del servicio "db" como DB_HOST cuando ejecutes
+   # Docker Compose. Evita utilizar la IP interna de los contenedores, ya que
+   # puede cambiar en cada reinicio.
+   # Si despliegas la BD sin contenedores pon DB_HOST=localhost
    ```
 4. Verifica que `docker-compose.yml` apunte al archivo `server/.env` para que
    la base de datos y la aplicación compartan las mismas credenciales.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,12 @@ services:
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-rootpass}
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "$DB_USER", "-p$DB_PASSWORD"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
     volumes:
       - dbdata:/var/lib/mysql
     ports:
@@ -19,8 +25,11 @@ services:
     build: .
     env_file:
       - server/.env
+    environment:
+      DB_HOST: db
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - "3001:3001"
     volumes:

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -2,12 +2,15 @@ const path = require('path');
 const { Sequelize, DataTypes } = require('sequelize');
 require('dotenv').config();
 
+const dbHost = process.env.DB_HOST
+  || (process.env.NODE_ENV === 'production' ? 'db' : 'localhost');
+
 const sequelize = new Sequelize(
   process.env.DB_NAME || 'mcm',
   process.env.DB_USER || 'root',
   process.env.DB_PASSWORD || '',
   {
-    host: process.env.DB_HOST || 'localhost',
+    host: dbHost,
     port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 3306,
     dialect: 'mariadb',
     pool: {
@@ -74,7 +77,7 @@ db.Node.hasMany(db.NodeAttachment, { as: 'attachments', foreignKey: 'nodeId' });
 db.NodeAttachment.belongsTo(db.Node, { foreignKey: 'nodeId' });
 
 
-async function initDatabase(retries = 5, delayMs = 2000) {
+async function initDatabase(retries = 20, delayMs = 2000) {
   for (let attempt = 1; ; attempt++) {
     try {
       await sequelize.authenticate();


### PR DESCRIPTION
## Summary
- ensure `db` is the default host in production builds
- increase DB connection retry attempts
- add database healthcheck and wait condition in `docker-compose.yml`
- clarify DB_HOST usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68630aeeb4408331a1d34dfc389071d8