### PR TITLE
Fix env loading for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@ server/node_modules
 client/dist
 export/*.sql
 server/.env
+.env
+

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+DB_NAME=mcm
+DB_USER=mcm
+DB_PASSWORD=clave_segura
+DB_ROOT_PASSWORD=rootpass
+DB_HOST=db
+DB_PORT=3306
+USE_AUTH=false
+SESSION_SECRET=mcm-secret
+LDAP_URL=ldap://ldap.example.com
+LDAP_BASE_DN=dc=example,dc=com
+LDAP_BIND_DN=cn=admin,dc=example,dc=com
+LDAP_BIND_PASSWORD=changeit

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ server/node_modules
 .env
 client/dist
 export/*.sql
+

--- a/README.md
+++ b/README.md
@@ -158,18 +158,19 @@ A continuación se describen todos los pasos necesarios para ejecutar la aplicac
    git clone <URL_DEL_REPOSITORIO> mcm
    cd mcm
    ```
-3. Copiar el archivo de ejemplo de variables de entorno y editarlo:
+3. Copiar el archivo de ejemplo de variables de entorno y editarlo. Es necesario
+   generar dos archivos: uno en la raíz para Docker Compose (`.env`) y otro en
+   `server/.env` para ejecutar la API de forma independiente:
    ```bash
+   cp server/.env.example .env
    cp server/.env.example server/.env
    # Establece en DB_PASSWORD la misma contraseña empleada al crear el usuario
-   # mcm. Docker Compose usará estas variables automáticamente.
-   # Usa siempre el nombre del servicio "db" como DB_HOST cuando ejecutes
-   # Docker Compose. Evita utilizar la IP interna de los contenedores, ya que
-   # puede cambiar en cada reinicio.
-   # Si despliegas la BD sin contenedores pon DB_HOST=localhost
+   # mcm. Docker Compose usará estas variables automáticamente. Usa siempre el
+   # nombre del servicio "db" como DB_HOST cuando ejecutes Docker Compose. Si la
+   # base de datos se ejecuta fuera de Docker, establece DB_HOST=localhost
    ```
-4. Verifica que `docker-compose.yml` apunte al archivo `server/.env` para que
-   la base de datos y la aplicación compartan las mismas credenciales.
+4. Asegúrate de que `docker-compose.yml` utiliza el archivo `.env` para cargar
+   las credenciales compartidas por la base de datos y la aplicación.
 
 ## 2.2 Puesta en marcha
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: mariadb:11
     restart: always
     env_file:
-      - server/.env
+      - .env
     environment:
       MYSQL_DATABASE: ${DB_NAME}
       MYSQL_USER: ${DB_USER}
@@ -24,7 +24,7 @@ services:
   app:
     build: .
     env_file:
-      - server/.env
+      - .env
     environment:
       DB_HOST: db
     depends_on:

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,9 @@
-require('dotenv').config();
+const path = require('path');
+const dotenv = require('dotenv');
+// Load variables for local development. In Docker, the environment is provided
+// via the `env_file` option in docker-compose.yml.
+dotenv.config({ path: path.join(__dirname, '.env') });
+console.log('Environment DB_USER:', process.env.DB_USER);
 const { app, db } = require('./app');
 
 db.initDatabase()

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,9 +1,20 @@
 const path = require('path');
 const { Sequelize, DataTypes } = require('sequelize');
-require('dotenv').config();
+const dotenv = require('dotenv');
+// Explicitly load the environment file if present. Docker containers will
+// receive the variables via the `env_file` option, so this is mainly for
+// local development.
+dotenv.config({ path: path.join(__dirname, '.env') });
 
 const dbHost = process.env.DB_HOST
   || (process.env.NODE_ENV === 'production' ? 'db' : 'localhost');
+
+console.log('DB connection parameters:', {
+  host: dbHost,
+  port: process.env.DB_PORT || 3306,
+  database: process.env.DB_NAME,
+  user: process.env.DB_USER
+});
 
 const sequelize = new Sequelize(
   process.env.DB_NAME || 'mcm',
@@ -141,6 +152,7 @@ async function initDatabase(retries = 20, delayMs = 2000) {
     } catch (err) {
       if (attempt >= retries) throw err;
       console.error(`Database connection failed (attempt ${attempt}). Retrying...`);
+      console.error('Error details:', err.message);
       await new Promise(res => setTimeout(res, delayMs));
     }
   }


### PR DESCRIPTION
## Summary
- centralize DB credentials in a new `.env` file
- log env variables and connection parameters on server startup
- show error details on DB connection failure
- update docker-compose to use `.env`
- document how to create `.env` and `server/.env`
- ignore `.env` during build and git

## Testing
- `npm --prefix client test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68630f8b8d808331afa4f0428e5d0fa0