### PR TITLE
Improve DB logs and remove healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,7 @@ services:
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-rootpass}
-    healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u$MYSQL_USER -p$MYSQL_PASSWORD"]
-      interval: 5s
-      timeout: 5s
-      retries: 20
-      start_period: 10s
+    entrypoint: ["sh", "-c", "echo MYSQL_USER=$MYSQL_USER; echo MYSQL_PASSWORD=$MYSQL_PASSWORD; echo MYSQL_DATABASE=$MYSQL_DATABASE; exec docker-entrypoint.sh mysqld"]
     volumes:
       - dbdata:/var/lib/mysql
     ports:
@@ -28,8 +23,7 @@ services:
     environment:
       DB_HOST: db
     depends_on:
-      db:
-        condition: service_healthy
+      - db
     ports:
       - "3001:3001"
     volumes:

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ const dotenv = require('dotenv');
 // via the `env_file` option in docker-compose.yml.
 dotenv.config({ path: path.join(__dirname, '.env') });
 console.log('Environment DB_USER:', process.env.DB_USER);
+console.log('Environment DB_PASSWORD:', process.env.DB_PASSWORD);
 const { app, db } = require('./app');
 
 db.initDatabase()

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -13,7 +13,8 @@ console.log('DB connection parameters:', {
   host: dbHost,
   port: process.env.DB_PORT || 3306,
   database: process.env.DB_NAME,
-  user: process.env.DB_USER
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD
 });
 
 const sequelize = new Sequelize(
@@ -91,6 +92,7 @@ db.NodeAttachment.belongsTo(db.Node, { foreignKey: 'nodeId' });
 async function initDatabase(retries = 20, delayMs = 2000) {
   for (let attempt = 1; ; attempt++) {
     try {
+      console.log(`Attempt ${attempt}: authenticating to DB`);
       await sequelize.authenticate();
 
       const queryInterface = sequelize.getQueryInterface();
@@ -153,6 +155,7 @@ async function initDatabase(retries = 20, delayMs = 2000) {
       if (attempt >= retries) throw err;
       console.error(`Database connection failed (attempt ${attempt}). Retrying...`);
       console.error('Error details:', err.message);
+      console.error('Stack:', err.stack);
       await new Promise(res => setTimeout(res, delayMs));
     }
   }


### PR DESCRIPTION
## Summary
- show DB password when server starts
- include password in Sequelize connection params and log attempts
- print stack traces for DB connection errors
- remove DB healthcheck from docker compose and print env values

## Testing
- `npm test` in `server` *(fails: Missing script)*
- `npm test` in `client` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686312beae908331a68c9ff12c263f1b