### PR TITLE
Fix compose deprecation warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   db:
     image: mariadb:11


### PR DESCRIPTION
## Summary
- remove obsolete `version` key from `docker-compose.yml`

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863143c50f08331bb5659844896fe5e