### PR TITLE
Fix LDAP auth middleware

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -42,6 +42,7 @@ const authRoutes = require('./routes/auth');
 if (process.env.USE_AUTH && process.env.USE_AUTH !== 'false') {
   app.use('/api/auth', authRoutes);
   app.use((req, res, next) => {
+    if (!req.path.startsWith('/api/')) return next();
     if (req.path.startsWith('/api/auth')) return next();
     if (req.session && req.session.user) return next();
     res.status(401).json({ error: 'Unauthorized' });


### PR DESCRIPTION
## Summary
- tweak auth middleware so static files are served when authentication is enabled

## Testing
- `npm test --silent` (client)
- `npm test --silent` (server)

------
https://chatgpt.com/codex/tasks/task_e_6867a52d335c8331ad1faaa400cbdd2d