### PR TITLE
Make DB host port configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ DB_PASSWORD=clave_segura
 DB_ROOT_PASSWORD=rootpass
 DB_HOST=db
 DB_PORT=3306
+DB_PORT_HOST=3306 # Puerto expuesto en el host para MariaDB
 MYSQL_DATABASE=mcm
 MYSQL_USER=mcm
 MYSQL_PASSWORD=clave_segura #Mismo valor que DB_PASSWORD

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Esta guía explica cómo poner en marcha la aplicación desde cero en un servido
    
    
    ```sql
-    mysql -h localhost -P 3306 -u root -p
+    # Sustituye <PUERTO_HOST> por el puerto configurado en DB_PORT_HOST
+    mysql -h localhost -P <PUERTO_HOST> -u root -p
    ```
 3. **Preparar la base de datos**
    ```sql
@@ -47,9 +48,14 @@ Esta guía explica cómo poner en marcha la aplicación desde cero en un servido
    DB_HOST=localhost   # usa "db" si la base de datos se ejecuta con Docker Compose. Usa "localhost" si se despliega la bd sin contenedores
    # Puerto por defecto de MariaDB/MySQL. Cambiar si se usa otro
    DB_PORT=3306
+   # Puerto expuesto en el host para MariaDB
+   DB_PORT_HOST=3306
    ENV
    cd ..
    ```
+
+   Cambia `DB_PORT_HOST` si necesitas exponer la base de datos en otro puerto
+   del host porque ya haya otro servicio escuchando en `3306`.
 
    Esta contraseña se reutiliza por Docker para crear la base de datos
    inicial, por lo que cualquier cambio debe reflejarse tanto en el script

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     volumes:
       - dbdata:/var/lib/mysql
     ports:
-      - "3306:3306"
+      # Ajusta DB_PORT_HOST en .env para exponer la base en otro puerto
+      - "${DB_PORT_HOST:-3306}:3306"
 
   app:
     build: .

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,6 +5,7 @@ DB_PASSWORD=clave_segura
 DB_ROOT_PASSWORD=rootpass
 DB_HOST=db # usar "localhost" si la base de datos se ejecuta fuera de Docker. Usar "db" si se usa Docker Compose para el despliegue
 DB_PORT=3306
+DB_PORT_HOST=3306 # Puerto expuesto en el host para MariaDB
 MYSQL_DATABASE=mcm
 MYSQL_USER=mcm
 MYSQL_PASSWORD=clave_segura #Mismo valor que DB_PASSWORD


### PR DESCRIPTION
## Summary
- allow customizing DB host port through `DB_PORT_HOST`
- document new variable in README

## Testing
- `npm test` in `client` *(fails: Missing script)*
- `npm test` in `server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867a65fc340833191e2f0acb42a115a