### PR TITLE
Fix DB_PORT usage with docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,11 @@ DB_USER=mcm
 DB_PASSWORD=clave_segura
 DB_ROOT_PASSWORD=rootpass
 DB_HOST=db
+# Puerto interno para la aplicación. Con Docker Compose siempre es 3306.
 DB_PORT=3306
-DB_PORT_HOST=3306 # Puerto expuesto en el host para MariaDB
+# Puerto expuesto en el host para MariaDB. Cambia solo este valor si necesitas
+# que el contenedor escuche en otro puerto (ej. 3308)
+DB_PORT_HOST=3306
 MYSQL_DATABASE=mcm
 MYSQL_USER=mcm
 MYSQL_PASSWORD=clave_segura #Mismo valor que DB_PASSWORD

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ Esta guía explica cómo poner en marcha la aplicación desde cero en un servido
    DB_PASSWORD=<TU_CONTRASENA>
    DB_ROOT_PASSWORD=rootpass
    DB_HOST=localhost   # usa "db" si la base de datos se ejecuta con Docker Compose. Usa "localhost" si se despliega la bd sin contenedores
-   # Puerto por defecto de MariaDB/MySQL. Cambiar si se usa otro
+   # Puerto de MariaDB al que se conecta la aplicación. Con Docker Compose se
+   # mantiene en 3306 porque es el puerto interno del contenedor.
    DB_PORT=3306
-   # Puerto expuesto en el host para MariaDB
+   # Puerto expuesto en el host para MariaDB. Cambia solo este valor si
+   # necesitas que el contenedor escuche en otro puerto del host (por ejemplo
+   # 3308). La aplicación seguirá usando DB_PORT=3306 para conectar con el
+   # servicio "db".
    DB_PORT_HOST=3306
    ENV
    cd ..

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,8 +4,12 @@ DB_USER=mcm
 DB_PASSWORD=clave_segura
 DB_ROOT_PASSWORD=rootpass
 DB_HOST=db # usar "localhost" si la base de datos se ejecuta fuera de Docker. Usar "db" si se usa Docker Compose para el despliegue
+# Puerto interno al que se conecta la aplicación. Si usas Docker Compose debe
+# permanecer en 3306.
 DB_PORT=3306
-DB_PORT_HOST=3306 # Puerto expuesto en el host para MariaDB
+# Puerto expuesto en el host. Modifica sólo este valor para cambiar el puerto en
+# el que escuchará MariaDB desde fuera del contenedor.
+DB_PORT_HOST=3306
 MYSQL_DATABASE=mcm
 MYSQL_USER=mcm
 MYSQL_PASSWORD=clave_segura #Mismo valor que DB_PASSWORD

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -9,9 +9,13 @@ dotenv.config({ path: path.join(__dirname, '.env') });
 const dbHost = process.env.DB_HOST
   || (process.env.NODE_ENV === 'production' ? 'db' : 'localhost');
 
+const dbPort = dbHost === 'db'
+  ? 3306
+  : (process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 3306);
+
 console.log('DB connection parameters:', {
   host: dbHost,
-  port: process.env.DB_PORT || 3306,
+  port: dbPort,
   database: process.env.DB_NAME,
   user: process.env.DB_USER,
   password: process.env.DB_PASSWORD
@@ -23,7 +27,7 @@ const sequelize = new Sequelize(
   process.env.DB_PASSWORD || '',
   {
     host: dbHost,
-    port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 3306,
+    port: dbPort,
     dialect: 'mariadb',
     pool: {
       max: parseInt(process.env.DB_POOL_MAX || '20', 10),


### PR DESCRIPTION
## Summary
- keep internal db port fixed at 3306 when using docker
- clarify DB_PORT and DB_PORT_HOST in docs and env examples
- log and use computed dbPort in database init

## Testing
- `npm --version`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6867b07e8ed083319e85ade54798a436